### PR TITLE
Implement friction heuristics library

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,3 +35,17 @@ export { PiCodingAgentAdapter } from "./adapters/pi-coding-agent.js";
 export type { PiCodingAgentAdapterOptions } from "./adapters/pi-coding-agent.js";
 
 export { loadConfig } from "./lib/config.js";
+
+export {
+  levenshteinRatio,
+  detectRephraseStorm,
+  detectToolFailureCascade,
+  detectContextChurn,
+  detectPermissionFriction,
+  detectAbandonSignal,
+  detectLongStall,
+  detectRetryLoop,
+  inferLanguages,
+  classifyOutcome,
+  extractFacets,
+} from "./lib/heuristics.js";

--- a/src/lib/heuristics.ts
+++ b/src/lib/heuristics.ts
@@ -1,0 +1,442 @@
+import type {
+  NormalizedEvent,
+  FrictionSignal,
+  Severity,
+  SessionFacets,
+  SessionOutcome,
+  TaggerConfig,
+} from "./types.js";
+
+// ── String similarity ───────────────────────────────────────────────
+
+/** Compute Levenshtein distance between two strings. */
+function levenshteinDistance(a: string, b: string): number {
+  const la = a.length;
+  const lb = b.length;
+  if (la === 0) return lb;
+  if (lb === 0) return la;
+
+  // Use single-row optimization
+  let prev = new Array<number>(lb + 1);
+  let curr = new Array<number>(lb + 1);
+
+  for (let j = 0; j <= lb; j++) prev[j] = j;
+
+  for (let i = 1; i <= la; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= lb; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(
+        prev[j]! + 1,      // deletion
+        curr[j - 1]! + 1,  // insertion
+        prev[j - 1]! + cost, // substitution
+      );
+    }
+    [prev, curr] = [curr, prev];
+  }
+
+  return prev[lb]!;
+}
+
+/** Compute similarity ratio (0–1) between two strings. 1 = identical. */
+export function levenshteinRatio(a: string, b: string): number {
+  const maxLen = Math.max(a.length, b.length);
+  if (maxLen === 0) return 1;
+  return 1 - levenshteinDistance(a, b) / maxLen;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function timeDiffSeconds(a: string, b: string): number {
+  return (Date.parse(b) - Date.parse(a)) / 1000;
+}
+
+function severityFromCount(count: number, lowThreshold: number, highThreshold: number): Severity {
+  if (count >= highThreshold) return "high";
+  if (count >= lowThreshold) return "medium";
+  return "low";
+}
+
+// ── Friction detectors ──────────────────────────────────────────────
+
+/**
+ * Detect rephrase storm: user rephrases similar prompts multiple times.
+ */
+export function detectRephraseStorm(
+  events: NormalizedEvent[],
+  config: TaggerConfig,
+): FrictionSignal | null {
+  const prompts = events
+    .map((e, i) => ({ event: e, index: i }))
+    .filter((x) => x.event.type === "user_prompt" && x.event.message);
+
+  if (prompts.length < 2) return null;
+
+  let rephraseCount = 0;
+  const indices: number[] = [];
+  const samples: string[] = [];
+
+  for (let i = 1; i < prompts.length; i++) {
+    const prev = prompts[i - 1]!;
+    const curr = prompts[i]!;
+    const ratio = levenshteinRatio(prev.event.message!, curr.event.message!);
+
+    if (ratio >= config.rephrase_similarity) {
+      rephraseCount++;
+      if (indices.length === 0) indices.push(prev.index);
+      indices.push(curr.index);
+      if (samples.length < 3) samples.push(curr.event.message!);
+    }
+  }
+
+  if (rephraseCount < config.rephrase_threshold) return null;
+
+  return {
+    type: "rephrase_storm",
+    severity: severityFromCount(rephraseCount, config.rephrase_threshold, config.rephrase_threshold * 2),
+    count: rephraseCount,
+    context: `User rephrased ${rephraseCount} times with similarity >= ${config.rephrase_similarity}`,
+    evidence: {
+      event_indices: indices,
+      sample_data: samples.join(" | "),
+    },
+  };
+}
+
+/**
+ * Detect tool failure cascade: consecutive tool failures.
+ */
+export function detectToolFailureCascade(
+  events: NormalizedEvent[],
+  config: TaggerConfig,
+): FrictionSignal | null {
+  let maxStreak = 0;
+  let currentStreak = 0;
+  let streakIndices: number[] = [];
+  let bestIndices: number[] = [];
+
+  for (let i = 0; i < events.length; i++) {
+    const event = events[i]!;
+    if (event.type !== "tool_result") continue;
+
+    if (event.tool_result?.success === false) {
+      currentStreak++;
+      streakIndices.push(i);
+      if (currentStreak > maxStreak) {
+        maxStreak = currentStreak;
+        bestIndices = [...streakIndices];
+      }
+    } else {
+      currentStreak = 0;
+      streakIndices = [];
+    }
+  }
+
+  if (maxStreak < config.tool_failure_cascade_min) return null;
+
+  const failedTools = bestIndices.map((i) => events[i]!.tool_name).filter(Boolean);
+
+  return {
+    type: "tool_failure_cascade",
+    severity: severityFromCount(maxStreak, config.tool_failure_cascade_min, config.tool_failure_cascade_min * 2),
+    count: maxStreak,
+    context: `${maxStreak} consecutive tool failures`,
+    evidence: {
+      event_indices: bestIndices,
+      sample_data: failedTools.join(", "),
+    },
+  };
+}
+
+/**
+ * Detect context churn: excessive compaction events.
+ */
+export function detectContextChurn(
+  events: NormalizedEvent[],
+  config: TaggerConfig,
+): FrictionSignal | null {
+  const compactions = events
+    .map((e, i) => ({ index: i, event: e }))
+    .filter((x) => x.event.type === "compaction");
+
+  if (compactions.length < config.context_churn_threshold) return null;
+
+  return {
+    type: "context_churn",
+    severity: severityFromCount(compactions.length, config.context_churn_threshold, config.context_churn_threshold * 2),
+    count: compactions.length,
+    context: `${compactions.length} context compaction events in session`,
+    evidence: {
+      event_indices: compactions.map((c) => c.index),
+    },
+  };
+}
+
+/**
+ * Detect permission friction: permission denied then retried.
+ */
+export function detectPermissionFriction(
+  events: NormalizedEvent[],
+  _config: TaggerConfig,
+): FrictionSignal | null {
+  const permEvents = events
+    .map((e, i) => ({ index: i, event: e }))
+    .filter((x) => x.event.type === "permission_result");
+
+  let denials = 0;
+  const indices: number[] = [];
+
+  for (const pe of permEvents) {
+    if (pe.event.permission_granted === false) {
+      denials++;
+      indices.push(pe.index);
+    }
+  }
+
+  if (denials === 0) return null;
+
+  return {
+    type: "permission_friction",
+    severity: severityFromCount(denials, 1, 3),
+    count: denials,
+    context: `${denials} permission denial(s) in session`,
+    evidence: {
+      event_indices: indices,
+    },
+  };
+}
+
+/**
+ * Detect abandon signal: session ended shortly after failures without resolution.
+ */
+export function detectAbandonSignal(
+  events: NormalizedEvent[],
+  config: TaggerConfig,
+): FrictionSignal | null {
+  // Find last session_end
+  let endIndex = -1;
+  for (let i = events.length - 1; i >= 0; i--) {
+    if (events[i]!.type === "session_end") {
+      endIndex = i;
+      break;
+    }
+  }
+  if (endIndex === -1) return null;
+
+  const endTs = events[endIndex]!.timestamp;
+
+  // Look for failures within the abandon window before session end
+  const failures: number[] = [];
+  for (let i = endIndex - 1; i >= 0; i--) {
+    const event = events[i]!;
+    const gap = timeDiffSeconds(event.timestamp, endTs);
+    if (gap > config.abandon_window_seconds) break;
+
+    if (event.type === "tool_result" && event.tool_result?.success === false) {
+      failures.push(i);
+    }
+  }
+
+  if (failures.length === 0) return null;
+
+  // Check if there was any success after the failures
+  const lastFailure = Math.max(...failures);
+  const hasSuccessAfter = events.slice(lastFailure + 1, endIndex).some(
+    (e) => e.type === "tool_result" && e.tool_result?.success === true,
+  );
+
+  if (hasSuccessAfter) return null;
+
+  return {
+    type: "abandon_signal",
+    severity: severityFromCount(failures.length, 1, 3),
+    count: failures.length,
+    context: `Session ended within ${config.abandon_window_seconds}s of ${failures.length} unresolved failure(s)`,
+    evidence: {
+      event_indices: [...failures, endIndex],
+    },
+  };
+}
+
+/**
+ * Detect long stall: large time gaps between consecutive events.
+ */
+export function detectLongStall(
+  events: NormalizedEvent[],
+  config: TaggerConfig,
+): FrictionSignal | null {
+  let stalls = 0;
+  const indices: number[] = [];
+
+  for (let i = 1; i < events.length; i++) {
+    const gap = timeDiffSeconds(events[i - 1]!.timestamp, events[i]!.timestamp);
+    if (gap >= config.stall_threshold_seconds) {
+      stalls++;
+      indices.push(i - 1, i);
+    }
+  }
+
+  if (stalls === 0) return null;
+
+  return {
+    type: "long_stall",
+    severity: severityFromCount(stalls, 1, 3),
+    count: stalls,
+    context: `${stalls} stall(s) exceeding ${config.stall_threshold_seconds}s`,
+    evidence: {
+      event_indices: [...new Set(indices)],
+    },
+  };
+}
+
+/**
+ * Detect retry loop: same command executed repeatedly.
+ */
+export function detectRetryLoop(
+  events: NormalizedEvent[],
+  config: TaggerConfig,
+): FrictionSignal | null {
+  const toolUses = events
+    .map((e, i) => ({ index: i, event: e }))
+    .filter((x) => x.event.type === "tool_use" && x.event.tool_input);
+
+  if (toolUses.length < 2) return null;
+
+  let maxStreak = 0;
+  let currentStreak = 1;
+  let streakIndices: number[] = [];
+  let bestIndices: number[] = [];
+
+  for (let i = 1; i < toolUses.length; i++) {
+    const prev = toolUses[i - 1]!;
+    const curr = toolUses[i]!;
+
+    const prevInput = JSON.stringify(prev.event.tool_input);
+    const currInput = JSON.stringify(curr.event.tool_input);
+    const ratio = levenshteinRatio(prevInput, currInput);
+
+    if (prev.event.tool_name === curr.event.tool_name && ratio >= config.retry_similarity) {
+      if (currentStreak === 1) streakIndices = [prev.index];
+      currentStreak++;
+      streakIndices.push(curr.index);
+      if (currentStreak > maxStreak) {
+        maxStreak = currentStreak;
+        bestIndices = [...streakIndices];
+      }
+    } else {
+      currentStreak = 1;
+      streakIndices = [];
+    }
+  }
+
+  if (maxStreak < config.retry_loop_min) return null;
+
+  return {
+    type: "retry_loop",
+    severity: severityFromCount(maxStreak, config.retry_loop_min, config.retry_loop_min * 2),
+    count: maxStreak,
+    context: `Same tool executed ${maxStreak} times with similarity >= ${config.retry_similarity}`,
+    evidence: {
+      event_indices: bestIndices,
+    },
+  };
+}
+
+// ── Facet extraction ────────────────────────────────────────────────
+
+const EXTENSION_TO_LANGUAGE: Record<string, string> = {
+  ts: "TypeScript", tsx: "TypeScript",
+  js: "JavaScript", jsx: "JavaScript", mjs: "JavaScript",
+  py: "Python", pyw: "Python",
+  rb: "Ruby", erb: "Ruby",
+  rs: "Rust",
+  go: "Go",
+  java: "Java",
+  kt: "Kotlin", kts: "Kotlin",
+  swift: "Swift",
+  cs: "C#",
+  cpp: "C++", cc: "C++", cxx: "C++", hpp: "C++", hxx: "C++",
+  c: "C", h: "C",
+  php: "PHP",
+  scala: "Scala",
+  sh: "Shell", bash: "Shell", zsh: "Shell",
+  sql: "SQL",
+  html: "HTML", htm: "HTML",
+  css: "CSS", scss: "CSS", sass: "CSS", less: "CSS",
+  json: "JSON",
+  yaml: "YAML", yml: "YAML",
+  md: "Markdown",
+  xml: "XML",
+  toml: "TOML",
+};
+
+/** Infer programming languages from file paths in tool events. */
+export function inferLanguages(events: NormalizedEvent[]): string[] {
+  const languages = new Set<string>();
+
+  for (const event of events) {
+    if (event.type !== "tool_use" && event.type !== "tool_result") continue;
+    const input = event.tool_input;
+    if (!input) continue;
+
+    // Look for file paths in common input keys
+    for (const key of ["file_path", "path", "target_file", "filePath"]) {
+      const val = input[key];
+      if (typeof val !== "string") continue;
+      const ext = val.split(".").pop()?.toLowerCase();
+      if (ext) {
+        const lang = EXTENSION_TO_LANGUAGE[ext];
+        if (lang) languages.add(lang);
+      }
+    }
+  }
+
+  return [...languages].sort();
+}
+
+/** Classify session outcome from events. */
+export function classifyOutcome(events: NormalizedEvent[], config: TaggerConfig): SessionOutcome {
+  let lastEnd: NormalizedEvent | undefined;
+  for (let i = events.length - 1; i >= 0; i--) {
+    if (events[i]!.type === "session_end") {
+      lastEnd = events[i]!;
+      break;
+    }
+  }
+  if (!lastEnd) return "abandoned";
+
+  // Check for abandon signal
+  const abandonSignal = detectAbandonSignal(events, config);
+  if (abandonSignal) return "abandoned";
+
+  // Check for high tool failure rate at end
+  const lastResults = events.filter((e) => e.type === "tool_result").slice(-3);
+  const allFailed = lastResults.length > 0 && lastResults.every((e) => e.tool_result?.success === false);
+  if (allFailed) return "errored";
+
+  return "completed";
+}
+
+/** Extract session facets from an event stream. */
+export function extractFacets(events: NormalizedEvent[], config: TaggerConfig): SessionFacets {
+  const toolResults = events.filter((e) => e.type === "tool_result");
+  const failedResults = toolResults.filter((e) => e.tool_result?.success === false);
+  const toolNames = new Set<string>();
+  for (const e of events) {
+    if (e.tool_name) toolNames.add(e.tool_name);
+  }
+
+  const timestamps = events.map((e) => Date.parse(e.timestamp)).filter((t) => !Number.isNaN(t));
+  const durationMs = timestamps.length >= 2
+    ? Math.max(...timestamps) - Math.min(...timestamps)
+    : 0;
+
+  return {
+    languages: inferLanguages(events),
+    tools_used: [...toolNames].sort(),
+    tool_failure_rate: toolResults.length > 0 ? failedResults.length / toolResults.length : 0,
+    session_duration_min: durationMs / 60_000,
+    total_turns: events.filter((e) => e.type === "user_prompt").length,
+    outcome: classifyOutcome(events, config),
+  };
+}

--- a/src/lib/heuristics.ts
+++ b/src/lib/heuristics.ts
@@ -235,7 +235,7 @@ export function detectAbandonSignal(
   for (let i = endIndex - 1; i >= 0; i--) {
     const event = events[i]!;
     const gap = timeDiffSeconds(event.timestamp, endTs);
-    if (Number.isNaN(gap)) continue;
+    if (Number.isNaN(gap)) break;
     if (gap > config.abandon_window_seconds) break;
 
     if (event.type === "tool_result" && event.tool_result?.success === false) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -93,7 +93,7 @@ export interface SessionFacets {
   languages: string[];
   /** Unique canonical tool names used in the session */
   tools_used: string[];
-  /** Ratio of tool failures to total tool uses (0–1) */
+  /** Ratio of failed tool results to total tool results (0–1) */
   tool_failure_rate: number;
   /** Session length in minutes */
   session_duration_min: number;

--- a/tests/heuristics.test.ts
+++ b/tests/heuristics.test.ts
@@ -435,6 +435,7 @@ describe("detectRetryLoop", () => {
     expect(result).not.toBeNull();
     expect(result!.count).toBe(4);
     // Verify the captured streak is the second (longer) shell_exec streak, not the first
+    expect(result!.evidence.event_indices.length).toBeGreaterThan(0);
     expect(result!.evidence.event_indices.every((i) => events[i]!.tool_name === "shell_exec")).toBe(true);
   });
 
@@ -635,7 +636,10 @@ describe("extractFacets", () => {
     // Duration based on valid timestamps only
     expect(facets.session_duration_min).toBe(1);
     expect(facets.outcome).toBe("completed");
-    // Tool metrics should still be computed from all tool events regardless of timestamp validity
+    // Tool metrics are computed from all tool events regardless of timestamp validity.
+    // This asserts current behavior: a tool_result with a malformed timestamp is still
+    // counted toward tool metrics. If extractFacets gains timestamp-based filtering for
+    // tool events, this test should surface that change.
     expect(facets.tools_used).toEqual(["file_read", "shell_exec"]);
     expect(facets.tool_failure_rate).toBe(0.5);
   });

--- a/tests/heuristics.test.ts
+++ b/tests/heuristics.test.ts
@@ -1,0 +1,617 @@
+import { describe, it, expect } from "bun:test";
+import type { NormalizedEvent, TaggerConfig } from "../src/lib/types.js";
+import {
+  levenshteinRatio,
+  detectRephraseStorm,
+  detectToolFailureCascade,
+  detectContextChurn,
+  detectPermissionFriction,
+  detectAbandonSignal,
+  detectLongStall,
+  detectRetryLoop,
+  inferLanguages,
+  classifyOutcome,
+  extractFacets,
+} from "../src/lib/heuristics.js";
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+const defaultConfig: TaggerConfig = {
+  rephrase_threshold: 3,
+  rephrase_similarity: 0.6,
+  tool_failure_cascade_min: 3,
+  context_churn_threshold: 2,
+  abandon_window_seconds: 120,
+  stall_threshold_seconds: 60,
+  retry_loop_min: 3,
+  retry_similarity: 0.7,
+};
+
+let idCounter = 0;
+function makeEvent(overrides: Partial<NormalizedEvent> & { type: NormalizedEvent["type"] }): NormalizedEvent {
+  idCounter++;
+  return {
+    id: `evt-${idCounter}`,
+    timestamp: "2026-02-05T10:00:00.000Z",
+    harness: "claude_code",
+    session_id: "test-session",
+    ...overrides,
+  };
+}
+
+function ts(minuteOffset: number): string {
+  const d = new Date("2026-02-05T10:00:00.000Z");
+  d.setMinutes(d.getMinutes() + minuteOffset);
+  return d.toISOString();
+}
+
+function tsSec(secondOffset: number): string {
+  const d = new Date("2026-02-05T10:00:00.000Z");
+  d.setSeconds(d.getSeconds() + secondOffset);
+  return d.toISOString();
+}
+
+// ── levenshteinRatio ────────────────────────────────────────────────
+
+describe("levenshteinRatio", () => {
+  it("returns 1 for identical strings", () => {
+    expect(levenshteinRatio("hello", "hello")).toBe(1);
+  });
+
+  it("returns 0 for completely different strings of equal length", () => {
+    expect(levenshteinRatio("abc", "xyz")).toBe(0);
+  });
+
+  it("returns 1 for two empty strings", () => {
+    expect(levenshteinRatio("", "")).toBe(1);
+  });
+
+  it("returns 0 when one string is empty", () => {
+    expect(levenshteinRatio("abc", "")).toBe(0);
+  });
+
+  it("computes correct ratio for similar strings", () => {
+    const ratio = levenshteinRatio("fix the bug", "fix the bugs");
+    expect(ratio).toBeGreaterThan(0.9);
+  });
+
+  it("computes correct ratio for moderately different strings", () => {
+    const ratio = levenshteinRatio("hello world", "goodbye world");
+    expect(ratio).toBeGreaterThan(0.4);
+    expect(ratio).toBeLessThan(0.8);
+  });
+});
+
+// ── detectRephraseStorm ─────────────────────────────────────────────
+
+describe("detectRephraseStorm", () => {
+  it("returns null when fewer than 2 prompts", () => {
+    const events = [makeEvent({ type: "user_prompt", message: "hello" })];
+    expect(detectRephraseStorm(events, defaultConfig)).toBeNull();
+  });
+
+  it("returns null when prompts are not similar enough", () => {
+    const events = [
+      makeEvent({ type: "user_prompt", message: "fix the authentication bug" }),
+      makeEvent({ type: "user_prompt", message: "add a new endpoint for users" }),
+      makeEvent({ type: "user_prompt", message: "refactor the database schema" }),
+      makeEvent({ type: "user_prompt", message: "update the readme file" }),
+    ];
+    expect(detectRephraseStorm(events, defaultConfig)).toBeNull();
+  });
+
+  it("returns null when rephrases are below threshold", () => {
+    const events = [
+      makeEvent({ type: "user_prompt", message: "fix the bug" }),
+      makeEvent({ type: "user_prompt", message: "fix the bugs" }),
+      // Only 1 rephrase pair, threshold is 3
+    ];
+    expect(detectRephraseStorm(events, defaultConfig)).toBeNull();
+  });
+
+  it("detects rephrase storm when threshold is met", () => {
+    const events = [
+      makeEvent({ type: "user_prompt", message: "fix the bug in login" }),
+      makeEvent({ type: "user_prompt", message: "fix the bug in login page" }),
+      makeEvent({ type: "user_prompt", message: "fix the bug in the login" }),
+      makeEvent({ type: "user_prompt", message: "fix the bugs in login" }),
+    ];
+    const result = detectRephraseStorm(events, defaultConfig);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("rephrase_storm");
+    expect(result!.count).toBeGreaterThanOrEqual(3);
+    expect(result!.evidence.event_indices.length).toBeGreaterThan(0);
+  });
+
+  it("reports correct severity based on count", () => {
+    const events = Array.from({ length: 8 }, (_, i) =>
+      makeEvent({ type: "user_prompt", message: `fix the bug attempt ${i}` }),
+    );
+    // With similarity 0.6, "fix the bug attempt 0" vs "fix the bug attempt 1" should match
+    const result = detectRephraseStorm(events, { ...defaultConfig, rephrase_threshold: 2, rephrase_similarity: 0.8 });
+    if (result) {
+      expect(["low", "medium", "high"]).toContain(result.severity);
+    }
+  });
+
+  it("ignores non-prompt events", () => {
+    const events = [
+      makeEvent({ type: "user_prompt", message: "fix the bug" }),
+      makeEvent({ type: "tool_use", tool_name: "file_read" }),
+      makeEvent({ type: "tool_result" }),
+      makeEvent({ type: "user_prompt", message: "fix the bugs" }),
+    ];
+    // Only 2 prompts, 1 pair, below threshold of 3
+    expect(detectRephraseStorm(events, defaultConfig)).toBeNull();
+  });
+});
+
+// ── detectToolFailureCascade ────────────────────────────────────────
+
+describe("detectToolFailureCascade", () => {
+  it("returns null when no tool results", () => {
+    const events = [makeEvent({ type: "user_prompt", message: "hello" })];
+    expect(detectToolFailureCascade(events, defaultConfig)).toBeNull();
+  });
+
+  it("returns null when failures are not consecutive", () => {
+    const events = [
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "err" } }),
+      makeEvent({ type: "tool_result", tool_result: { success: true } }),
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "err" } }),
+      makeEvent({ type: "tool_result", tool_result: { success: true } }),
+    ];
+    expect(detectToolFailureCascade(events, defaultConfig)).toBeNull();
+  });
+
+  it("detects cascade of consecutive failures", () => {
+    const events = [
+      makeEvent({ type: "tool_result", tool_name: "shell_exec", tool_result: { success: false, error: "err1" } }),
+      makeEvent({ type: "tool_result", tool_name: "shell_exec", tool_result: { success: false, error: "err2" } }),
+      makeEvent({ type: "tool_result", tool_name: "file_edit", tool_result: { success: false, error: "err3" } }),
+    ];
+    const result = detectToolFailureCascade(events, defaultConfig);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("tool_failure_cascade");
+    expect(result!.count).toBe(3);
+    expect(result!.evidence.sample_data).toContain("shell_exec");
+  });
+
+  it("tracks the longest streak", () => {
+    const events = [
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "e" } }),
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "e" } }),
+      makeEvent({ type: "tool_result", tool_result: { success: true } }),
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "e" } }),
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "e" } }),
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "e" } }),
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "e" } }),
+    ];
+    const result = detectToolFailureCascade(events, defaultConfig);
+    expect(result).not.toBeNull();
+    expect(result!.count).toBe(4);
+  });
+
+  it("ignores non-tool_result events when counting streak", () => {
+    const events = [
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "e" } }),
+      makeEvent({ type: "user_prompt", message: "retry" }),
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "e" } }),
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "e" } }),
+    ];
+    // Non-tool_result events are skipped, so all 3 failures are consecutive
+    const result = detectToolFailureCascade(events, defaultConfig);
+    expect(result).not.toBeNull();
+    expect(result!.count).toBe(3);
+  });
+});
+
+// ── detectContextChurn ──────────────────────────────────────────────
+
+describe("detectContextChurn", () => {
+  it("returns null when no compactions", () => {
+    const events = [makeEvent({ type: "user_prompt", message: "hello" })];
+    expect(detectContextChurn(events, defaultConfig)).toBeNull();
+  });
+
+  it("returns null when compactions are below threshold", () => {
+    const events = [makeEvent({ type: "compaction" })];
+    expect(detectContextChurn(events, defaultConfig)).toBeNull();
+  });
+
+  it("detects churn when compactions meet threshold", () => {
+    const events = [
+      makeEvent({ type: "compaction" }),
+      makeEvent({ type: "compaction" }),
+    ];
+    const result = detectContextChurn(events, defaultConfig);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("context_churn");
+    expect(result!.count).toBe(2);
+  });
+
+  it("reports high severity for many compactions", () => {
+    const events = Array.from({ length: 5 }, () => makeEvent({ type: "compaction" }));
+    const result = detectContextChurn(events, defaultConfig);
+    expect(result).not.toBeNull();
+    expect(result!.severity).toBe("high");
+  });
+});
+
+// ── detectPermissionFriction ────────────────────────────────────────
+
+describe("detectPermissionFriction", () => {
+  it("returns null when no permission events", () => {
+    const events = [makeEvent({ type: "user_prompt", message: "hello" })];
+    expect(detectPermissionFriction(events, defaultConfig)).toBeNull();
+  });
+
+  it("returns null when all permissions are granted", () => {
+    const events = [
+      makeEvent({ type: "permission_result", permission_granted: true }),
+      makeEvent({ type: "permission_result", permission_granted: true }),
+    ];
+    expect(detectPermissionFriction(events, defaultConfig)).toBeNull();
+  });
+
+  it("detects permission friction on denials", () => {
+    const events = [
+      makeEvent({ type: "permission_result", permission_granted: false }),
+    ];
+    const result = detectPermissionFriction(events, defaultConfig);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("permission_friction");
+    expect(result!.count).toBe(1);
+  });
+
+  it("counts multiple denials", () => {
+    const events = [
+      makeEvent({ type: "permission_result", permission_granted: false }),
+      makeEvent({ type: "permission_result", permission_granted: true }),
+      makeEvent({ type: "permission_result", permission_granted: false }),
+      makeEvent({ type: "permission_result", permission_granted: false }),
+    ];
+    const result = detectPermissionFriction(events, defaultConfig);
+    expect(result).not.toBeNull();
+    expect(result!.count).toBe(3);
+    expect(result!.severity).toBe("high");
+  });
+});
+
+// ── detectAbandonSignal ─────────────────────────────────────────────
+
+describe("detectAbandonSignal", () => {
+  it("returns null when no session_end", () => {
+    const events = [
+      makeEvent({ type: "user_prompt", message: "hello" }),
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "err" } }),
+    ];
+    expect(detectAbandonSignal(events, defaultConfig)).toBeNull();
+  });
+
+  it("returns null when no failures before session end", () => {
+    const events = [
+      makeEvent({ type: "user_prompt", message: "hello", timestamp: tsSec(0) }),
+      makeEvent({ type: "tool_result", tool_result: { success: true }, timestamp: tsSec(10) }),
+      makeEvent({ type: "session_end", timestamp: tsSec(20) }),
+    ];
+    expect(detectAbandonSignal(events, defaultConfig)).toBeNull();
+  });
+
+  it("returns null when failures are resolved before end", () => {
+    const events = [
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "err" }, timestamp: tsSec(0) }),
+      makeEvent({ type: "tool_result", tool_result: { success: true }, timestamp: tsSec(10) }),
+      makeEvent({ type: "session_end", timestamp: tsSec(20) }),
+    ];
+    expect(detectAbandonSignal(events, defaultConfig)).toBeNull();
+  });
+
+  it("detects abandon when failures are unresolved near session end", () => {
+    const events = [
+      makeEvent({ type: "user_prompt", message: "fix it", timestamp: tsSec(0) }),
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "err" }, timestamp: tsSec(50) }),
+      makeEvent({ type: "session_end", timestamp: tsSec(60) }),
+    ];
+    const result = detectAbandonSignal(events, defaultConfig);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("abandon_signal");
+    expect(result!.count).toBe(1);
+  });
+
+  it("ignores failures outside the abandon window", () => {
+    const events = [
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "old" }, timestamp: tsSec(0) }),
+      makeEvent({ type: "session_end", timestamp: tsSec(300) }), // 5 min later, outside 120s window
+    ];
+    expect(detectAbandonSignal(events, defaultConfig)).toBeNull();
+  });
+});
+
+// ── detectLongStall ─────────────────────────────────────────────────
+
+describe("detectLongStall", () => {
+  it("returns null with single event", () => {
+    const events = [makeEvent({ type: "user_prompt", message: "hello" })];
+    expect(detectLongStall(events, defaultConfig)).toBeNull();
+  });
+
+  it("returns null when gaps are below threshold", () => {
+    const events = [
+      makeEvent({ type: "user_prompt", message: "a", timestamp: tsSec(0) }),
+      makeEvent({ type: "user_prompt", message: "b", timestamp: tsSec(30) }),
+    ];
+    expect(detectLongStall(events, defaultConfig)).toBeNull();
+  });
+
+  it("detects stall when gap exceeds threshold", () => {
+    const events = [
+      makeEvent({ type: "user_prompt", message: "a", timestamp: tsSec(0) }),
+      makeEvent({ type: "user_prompt", message: "b", timestamp: tsSec(120) }), // 2 min gap
+    ];
+    const result = detectLongStall(events, defaultConfig);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("long_stall");
+    expect(result!.count).toBe(1);
+  });
+
+  it("counts multiple stalls", () => {
+    const events = [
+      makeEvent({ type: "user_prompt", timestamp: tsSec(0) }),
+      makeEvent({ type: "user_prompt", timestamp: tsSec(90) }),  // 90s gap
+      makeEvent({ type: "user_prompt", timestamp: tsSec(100) }), // 10s gap
+      makeEvent({ type: "user_prompt", timestamp: tsSec(200) }), // 100s gap
+    ];
+    const result = detectLongStall(events, defaultConfig);
+    expect(result).not.toBeNull();
+    expect(result!.count).toBe(2);
+  });
+});
+
+// ── detectRetryLoop ─────────────────────────────────────────────────
+
+describe("detectRetryLoop", () => {
+  it("returns null with fewer than 2 tool uses", () => {
+    const events = [makeEvent({ type: "tool_use", tool_name: "shell_exec", tool_input: { command: "test" } })];
+    expect(detectRetryLoop(events, defaultConfig)).toBeNull();
+  });
+
+  it("returns null when tool uses are different", () => {
+    const events = [
+      makeEvent({ type: "tool_use", tool_name: "shell_exec", tool_input: { command: "ls" } }),
+      makeEvent({ type: "tool_use", tool_name: "file_read", tool_input: { path: "/src/main.ts" } }),
+      makeEvent({ type: "tool_use", tool_name: "file_edit", tool_input: { path: "/src/main.ts" } }),
+    ];
+    expect(detectRetryLoop(events, defaultConfig)).toBeNull();
+  });
+
+  it("detects retry loop with repeated identical commands", () => {
+    const events = [
+      makeEvent({ type: "tool_use", tool_name: "shell_exec", tool_input: { command: "bun test" } }),
+      makeEvent({ type: "tool_use", tool_name: "shell_exec", tool_input: { command: "bun test" } }),
+      makeEvent({ type: "tool_use", tool_name: "shell_exec", tool_input: { command: "bun test" } }),
+    ];
+    const result = detectRetryLoop(events, defaultConfig);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("retry_loop");
+    expect(result!.count).toBe(3);
+  });
+
+  it("detects retry loop with similar but not identical commands", () => {
+    const events = [
+      makeEvent({ type: "tool_use", tool_name: "shell_exec", tool_input: { command: "bun test --bail" } }),
+      makeEvent({ type: "tool_use", tool_name: "shell_exec", tool_input: { command: "bun test --bail" } }),
+      makeEvent({ type: "tool_use", tool_name: "shell_exec", tool_input: { command: "bun test --bail " } }),
+    ];
+    const result = detectRetryLoop(events, defaultConfig);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("retry_loop");
+  });
+
+  it("does not group different tool names", () => {
+    const events = [
+      makeEvent({ type: "tool_use", tool_name: "shell_exec", tool_input: { command: "test" } }),
+      makeEvent({ type: "tool_use", tool_name: "file_read", tool_input: { command: "test" } }),
+      makeEvent({ type: "tool_use", tool_name: "shell_exec", tool_input: { command: "test" } }),
+    ];
+    expect(detectRetryLoop(events, defaultConfig)).toBeNull();
+  });
+
+  it("ignores tool uses without tool_input", () => {
+    const events = [
+      makeEvent({ type: "tool_use", tool_name: "shell_exec" }),
+      makeEvent({ type: "tool_use", tool_name: "shell_exec" }),
+      makeEvent({ type: "tool_use", tool_name: "shell_exec" }),
+    ];
+    expect(detectRetryLoop(events, defaultConfig)).toBeNull();
+  });
+});
+
+// ── inferLanguages ──────────────────────────────────────────────────
+
+describe("inferLanguages", () => {
+  it("returns empty for non-tool events", () => {
+    const events = [makeEvent({ type: "user_prompt", message: "hello" })];
+    expect(inferLanguages(events)).toEqual([]);
+  });
+
+  it("infers TypeScript from .ts files", () => {
+    const events = [
+      makeEvent({ type: "tool_use", tool_input: { file_path: "/src/main.ts" } }),
+    ];
+    expect(inferLanguages(events)).toEqual(["TypeScript"]);
+  });
+
+  it("infers multiple languages", () => {
+    const events = [
+      makeEvent({ type: "tool_use", tool_input: { file_path: "/src/main.ts" } }),
+      makeEvent({ type: "tool_use", tool_input: { path: "/app.py" } }),
+      makeEvent({ type: "tool_result", tool_input: { target_file: "/style.css" } }),
+    ];
+    const langs = inferLanguages(events);
+    expect(langs).toContain("TypeScript");
+    expect(langs).toContain("Python");
+    expect(langs).toContain("CSS");
+  });
+
+  it("deduplicates languages", () => {
+    const events = [
+      makeEvent({ type: "tool_use", tool_input: { file_path: "/a.ts" } }),
+      makeEvent({ type: "tool_use", tool_input: { file_path: "/b.tsx" } }),
+    ];
+    expect(inferLanguages(events)).toEqual(["TypeScript"]);
+  });
+
+  it("returns sorted languages", () => {
+    const events = [
+      makeEvent({ type: "tool_use", tool_input: { path: "/z.py" } }),
+      makeEvent({ type: "tool_use", tool_input: { path: "/a.ts" } }),
+      makeEvent({ type: "tool_use", tool_input: { path: "/m.go" } }),
+    ];
+    const langs = inferLanguages(events);
+    expect(langs).toEqual(["Go", "Python", "TypeScript"]);
+  });
+
+  it("handles unknown extensions", () => {
+    const events = [
+      makeEvent({ type: "tool_use", tool_input: { file_path: "/data.xyz" } }),
+    ];
+    expect(inferLanguages(events)).toEqual([]);
+  });
+
+  it("checks filePath key variant", () => {
+    const events = [
+      makeEvent({ type: "tool_use", tool_input: { filePath: "/src/main.rs" } }),
+    ];
+    expect(inferLanguages(events)).toEqual(["Rust"]);
+  });
+});
+
+// ── classifyOutcome ─────────────────────────────────────────────────
+
+describe("classifyOutcome", () => {
+  it("returns abandoned when no session_end", () => {
+    const events = [makeEvent({ type: "user_prompt", message: "hello" })];
+    expect(classifyOutcome(events, defaultConfig)).toBe("abandoned");
+  });
+
+  it("returns completed for clean session", () => {
+    const events = [
+      makeEvent({ type: "session_start", timestamp: tsSec(0) }),
+      makeEvent({ type: "user_prompt", message: "fix bug", timestamp: tsSec(1) }),
+      makeEvent({ type: "tool_result", tool_result: { success: true }, timestamp: tsSec(10) }),
+      makeEvent({ type: "session_end", timestamp: tsSec(20) }),
+    ];
+    expect(classifyOutcome(events, defaultConfig)).toBe("completed");
+  });
+
+  it("returns errored when last tool results all failed but no abandon signal", () => {
+    // Failures must be far from session_end to avoid triggering abandon_signal
+    const events = [
+      makeEvent({ type: "session_start", timestamp: tsSec(0) }),
+      makeEvent({ type: "tool_result", tool_result: { success: true }, timestamp: tsSec(5) }),
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "e" }, timestamp: tsSec(10) }),
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "e" }, timestamp: tsSec(15) }),
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "e" }, timestamp: tsSec(20) }),
+      // session_end well outside the abandon_window_seconds (120s)
+      makeEvent({ type: "session_end", timestamp: tsSec(300) }),
+    ];
+    expect(classifyOutcome(events, defaultConfig)).toBe("errored");
+  });
+
+  it("returns abandoned when abandon signal is detected", () => {
+    const events = [
+      makeEvent({ type: "session_start", timestamp: tsSec(0) }),
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "err" }, timestamp: tsSec(50) }),
+      makeEvent({ type: "session_end", timestamp: tsSec(60) }),
+    ];
+    expect(classifyOutcome(events, defaultConfig)).toBe("abandoned");
+  });
+});
+
+// ── extractFacets ───────────────────────────────────────────────────
+
+describe("extractFacets", () => {
+  it("extracts facets from a session", () => {
+    const events = [
+      makeEvent({ type: "session_start", timestamp: ts(0) }),
+      makeEvent({ type: "user_prompt", message: "fix bug", timestamp: ts(0) }),
+      makeEvent({ type: "tool_use", tool_name: "file_read", tool_input: { file_path: "/src/main.ts" }, timestamp: ts(1) }),
+      makeEvent({ type: "tool_result", tool_name: "file_read", tool_result: { success: true }, timestamp: ts(1) }),
+      makeEvent({ type: "tool_use", tool_name: "file_edit", tool_input: { file_path: "/src/main.ts" }, timestamp: ts(2) }),
+      makeEvent({ type: "tool_result", tool_name: "file_edit", tool_result: { success: true }, timestamp: ts(2) }),
+      makeEvent({ type: "session_end", timestamp: ts(5) }),
+    ];
+
+    const facets = extractFacets(events, defaultConfig);
+    expect(facets.languages).toEqual(["TypeScript"]);
+    expect(facets.tools_used).toEqual(["file_edit", "file_read"]);
+    expect(facets.tool_failure_rate).toBe(0);
+    expect(facets.session_duration_min).toBe(5);
+    expect(facets.total_turns).toBe(1);
+    expect(facets.outcome).toBe("completed");
+  });
+
+  it("computes tool failure rate", () => {
+    const events = [
+      makeEvent({ type: "session_start", timestamp: tsSec(0) }),
+      makeEvent({ type: "tool_result", tool_result: { success: true }, timestamp: tsSec(1) }),
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "e" }, timestamp: tsSec(2) }),
+      makeEvent({ type: "tool_result", tool_result: { success: true }, timestamp: tsSec(3) }),
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "e" }, timestamp: tsSec(4) }),
+      makeEvent({ type: "session_end", timestamp: tsSec(5) }),
+    ];
+
+    const facets = extractFacets(events, defaultConfig);
+    expect(facets.tool_failure_rate).toBe(0.5);
+  });
+
+  it("returns 0 failure rate when no tool results", () => {
+    const events = [
+      makeEvent({ type: "session_start", timestamp: tsSec(0) }),
+      makeEvent({ type: "user_prompt", message: "hello", timestamp: tsSec(1) }),
+      makeEvent({ type: "session_end", timestamp: tsSec(2) }),
+    ];
+
+    const facets = extractFacets(events, defaultConfig);
+    expect(facets.tool_failure_rate).toBe(0);
+  });
+
+  it("counts user prompts as total_turns", () => {
+    const events = [
+      makeEvent({ type: "session_start" }),
+      makeEvent({ type: "user_prompt", message: "a" }),
+      makeEvent({ type: "user_prompt", message: "b" }),
+      makeEvent({ type: "user_prompt", message: "c" }),
+      makeEvent({ type: "session_end" }),
+    ];
+
+    const facets = extractFacets(events, defaultConfig);
+    expect(facets.total_turns).toBe(3);
+  });
+
+  it("handles zero duration for single-timestamp session", () => {
+    const events = [
+      makeEvent({ type: "session_start", timestamp: tsSec(0) }),
+      makeEvent({ type: "session_end", timestamp: tsSec(0) }),
+    ];
+
+    const facets = extractFacets(events, defaultConfig);
+    expect(facets.session_duration_min).toBe(0);
+  });
+
+  it("collects unique tool names", () => {
+    const events = [
+      makeEvent({ type: "tool_use", tool_name: "file_read" }),
+      makeEvent({ type: "tool_result", tool_name: "file_read", tool_result: { success: true } }),
+      makeEvent({ type: "tool_use", tool_name: "shell_exec" }),
+      makeEvent({ type: "tool_result", tool_name: "shell_exec", tool_result: { success: true } }),
+      makeEvent({ type: "tool_use", tool_name: "file_read" }),
+      makeEvent({ type: "tool_result", tool_name: "file_read", tool_result: { success: true } }),
+      makeEvent({ type: "session_end" }),
+    ];
+
+    const facets = extractFacets(events, defaultConfig);
+    expect(facets.tools_used).toEqual(["file_read", "shell_exec"]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds all 7 friction detectors: rephrase_storm, tool_failure_cascade, context_churn, permission_friction, abandon_signal, long_stall, retry_loop
- Adds utility functions: levenshteinRatio (string similarity), inferLanguages (from file extensions), classifyOutcome (completed/abandoned/errored), extractFacets (session facets)
- Exports all public functions from src/index.ts
- 57 tests covering all detectors, edge cases, and utility functions

## Test plan
- [x] All 57 heuristics tests pass (`bun test tests/heuristics.test.ts`)
- [x] Full suite of 183 tests pass (`bun test`)
- [x] TypeScript typechecks clean (`bun run typecheck`)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)