### PR TITLE
Implement signal tagger (SessionEnd hook)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export {
   detectHarness,
   createAdapter,
   resolveScope,
+  resolveEventsDir,
   collectSignals,
   buildSignalRecord,
   signalsOutputDir,

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,19 @@ export type { PiCodingAgentAdapterOptions } from "./adapters/pi-coding-agent.js"
 
 export { loadConfig } from "./lib/config.js";
 
+export type { HookInput } from "./lib/tagger.js";
+export {
+  isHookInput,
+  detectHarness,
+  createAdapter,
+  resolveScope,
+  collectSignals,
+  buildSignalRecord,
+  signalsOutputDir,
+  signalsFilePath,
+  writeSignalRecord,
+} from "./lib/tagger.js";
+
 export {
   levenshteinRatio,
   detectRephraseStorm,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { HARNESS_TYPES } from "./lib/types.js";
 export type {
   HarnessType,
   NormalizedEventType,

--- a/src/lib/tagger.ts
+++ b/src/lib/tagger.ts
@@ -1,5 +1,5 @@
 import { mkdir, appendFile } from "node:fs/promises";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import { homedir } from "node:os";
 import { ClaudeCodeAdapter } from "../adapters/claude-code.js";
 import { GeminiCliAdapter } from "../adapters/gemini-cli.js";
@@ -36,9 +36,9 @@ export function isHookInput(obj: unknown): obj is HookInput {
 export function detectHarness(input: HookInput, config: Config): HarnessType | null {
   // If transcript_path hints at the harness, use that
   const tp = input.transcript_path ?? "";
-  if (tp.includes("/.claude/")) return "claude_code";
-  if (tp.includes("/.gemini/")) return "gemini_cli";
-  if (tp.includes("/.pi/")) return "pi_coding_agent";
+  if (tp.includes(`${sep}.claude${sep}`)) return "claude_code";
+  if (tp.includes(`${sep}.gemini${sep}`)) return "gemini_cli";
+  if (tp.includes(`${sep}.pi${sep}`)) return "pi_coding_agent";
 
   // Check environment variables
   if (process.env["CLAUDE_CODE_SESSION"]) return "claude_code";
@@ -88,7 +88,7 @@ export function resolveScope(cwd: string, config: Config): Scope {
   );
 
   for (const paiPath of expandedPaiPaths) {
-    if (cwd === paiPath || cwd.startsWith(paiPath + "/")) return "pai";
+    if (cwd === paiPath || cwd.startsWith(paiPath + sep)) return "pai";
   }
 
   return `project:${cwd}`;
@@ -145,6 +145,9 @@ export function signalsOutputDir(): string {
 
 export function signalsFilePath(date?: string): string {
   const d = date ?? new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(d)) {
+    throw new Error(`Invalid date format: expected YYYY-MM-DD, got "${d}"`);
+  }
   return join(signalsOutputDir(), `${d}_signals.jsonl`);
 }
 

--- a/src/lib/tagger.ts
+++ b/src/lib/tagger.ts
@@ -171,6 +171,9 @@ export function signalsFilePath(date?: string): string {
 export async function writeSignalRecord(record: SignalRecord, outputDir?: string): Promise<void> {
   const dir = outputDir ?? signalsOutputDir();
   await mkdir(dir, { recursive: true });
+  if (!record.timestamp.endsWith("Z")) {
+    throw new Error(`Timestamp must be UTC (ending in Z), got: "${record.timestamp}"`);
+  }
   const date = record.timestamp.slice(0, 10);
   if (!isValidDateString(date)) {
     throw new Error(`Invalid timestamp in signal record: "${record.timestamp}"`);

--- a/src/lib/tagger.ts
+++ b/src/lib/tagger.ts
@@ -145,7 +145,15 @@ export function signalsOutputDir(): string {
 
 export function signalsFilePath(date?: string): string {
   const d = date ?? new Date().toISOString().slice(0, 10); // YYYY-MM-DD
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(d) || isNaN(new Date(d).getTime())) {
+  let valid = /^\d{4}-\d{2}-\d{2}$/.test(d);
+  if (valid) {
+    try {
+      valid = new Date(d + "T00:00:00Z").toISOString().slice(0, 10) === d;
+    } catch {
+      valid = false;
+    }
+  }
+  if (!valid) {
     throw new Error(`Invalid date format: expected YYYY-MM-DD, got "${d}"`);
   }
   return join(signalsOutputDir(), `${d}_signals.jsonl`);

--- a/src/lib/tagger.ts
+++ b/src/lib/tagger.ts
@@ -1,0 +1,156 @@
+import { mkdir, appendFile } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { ClaudeCodeAdapter } from "../adapters/claude-code.js";
+import { GeminiCliAdapter } from "../adapters/gemini-cli.js";
+import { PiCodingAgentAdapter } from "../adapters/pi-coding-agent.js";
+import type { HarnessAdapter } from "../adapters/types.js";
+import type { Config, FrictionSignal, HarnessType, NormalizedEvent, Scope, SignalRecord } from "./types.js";
+import {
+  detectRephraseStorm,
+  detectToolFailureCascade,
+  detectContextChurn,
+  detectPermissionFriction,
+  detectAbandonSignal,
+  detectLongStall,
+  detectRetryLoop,
+  extractFacets,
+} from "./heuristics.js";
+
+// ── Hook input ──────────────────────────────────────────────────────
+
+export interface HookInput {
+  session_id: string;
+  cwd?: string;
+  transcript_path?: string;
+}
+
+export function isHookInput(obj: unknown): obj is HookInput {
+  if (typeof obj !== "object" || obj === null) return false;
+  const o = obj as Record<string, unknown>;
+  return typeof o["session_id"] === "string";
+}
+
+// ── Harness detection ───────────────────────────────────────────────
+
+export function detectHarness(input: HookInput, config: Config): HarnessType | null {
+  // If transcript_path hints at the harness, use that
+  const tp = input.transcript_path ?? "";
+  if (tp.includes(".claude")) return "claude_code";
+  if (tp.includes(".gemini")) return "gemini_cli";
+  if (tp.includes(".pi")) return "pi_coding_agent";
+
+  // Check environment variables
+  if (process.env["CLAUDE_CODE_SESSION"]) return "claude_code";
+  if (process.env["GEMINI_SESSION"]) return "gemini_cli";
+  if (process.env["PI_CODING_AGENT_DIR"]) return "pi_coding_agent";
+
+  // Default to the first enabled harness
+  for (const [key, value] of Object.entries(config.harnesses)) {
+    if (value.enabled) return key as HarnessType;
+  }
+
+  return null;
+}
+
+// ── Adapter factory ─────────────────────────────────────────────────
+
+function resolveEventsDir(dir: string): string {
+  if (dir.startsWith("~/")) {
+    return join(homedir(), dir.slice(2));
+  }
+  return dir;
+}
+
+export function createAdapter(harness: HarnessType, config: Config): HarnessAdapter | null {
+  const harnessConfig = config.harnesses[harness];
+  if (!harnessConfig?.enabled) return null;
+
+  const eventsDir = resolveEventsDir(harnessConfig.events_dir);
+
+  switch (harness) {
+    case "claude_code":
+      return new ClaudeCodeAdapter({ eventsDir });
+    case "gemini_cli":
+      return new GeminiCliAdapter({ eventsDir });
+    case "pi_coding_agent":
+      return new PiCodingAgentAdapter({ eventsDir });
+    default:
+      return null;
+  }
+}
+
+// ── Scope resolution ────────────────────────────────────────────────
+
+export function resolveScope(cwd: string, config: Config): Scope {
+  const expandedPaiPaths = config.scope_rules.pai_paths.map((p) =>
+    p.startsWith("~/") ? join(homedir(), p.slice(2)) : p,
+  );
+
+  for (const paiPath of expandedPaiPaths) {
+    if (cwd.startsWith(paiPath)) return "pai";
+  }
+
+  return `project:${cwd}`;
+}
+
+// ── Signal collection ───────────────────────────────────────────────
+
+export function collectSignals(events: NormalizedEvent[], config: Config): FrictionSignal[] {
+  const detectors = [
+    detectRephraseStorm,
+    detectToolFailureCascade,
+    detectContextChurn,
+    detectPermissionFriction,
+    detectAbandonSignal,
+    detectLongStall,
+    detectRetryLoop,
+  ];
+
+  const signals: FrictionSignal[] = [];
+  for (const detect of detectors) {
+    const signal = detect(events, config.tagger);
+    if (signal) signals.push(signal);
+  }
+  return signals;
+}
+
+// ── Signal record construction ──────────────────────────────────────
+
+export function buildSignalRecord(
+  sessionId: string,
+  events: NormalizedEvent[],
+  config: Config,
+  cwd: string,
+): SignalRecord {
+  const signals = collectSignals(events, config);
+  const facets = extractFacets(events, config.tagger);
+  const scope = resolveScope(cwd, config);
+
+  return {
+    session_id: sessionId,
+    timestamp: new Date().toISOString(),
+    project: cwd,
+    scope,
+    signals,
+    facets,
+  };
+}
+
+// ── Output ──────────────────────────────────────────────────────────
+
+export function signalsOutputDir(): string {
+  return join(homedir(), ".claude", "history", "signals");
+}
+
+export function signalsFilePath(): string {
+  const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+  return join(signalsOutputDir(), `${date}_signals.jsonl`);
+}
+
+export async function writeSignalRecord(record: SignalRecord): Promise<void> {
+  const dir = signalsOutputDir();
+  await mkdir(dir, { recursive: true });
+  const line = JSON.stringify(record) + "\n";
+  await appendFile(signalsFilePath(), line, "utf-8");
+}

--- a/src/lib/tagger.ts
+++ b/src/lib/tagger.ts
@@ -1,5 +1,5 @@
 import { mkdir, appendFile } from "node:fs/promises";
-import { join, sep } from "node:path";
+import { join } from "node:path";
 import { homedir } from "node:os";
 import { ClaudeCodeAdapter } from "../adapters/claude-code.js";
 import { GeminiCliAdapter } from "../adapters/gemini-cli.js";
@@ -36,9 +36,9 @@ export function isHookInput(obj: unknown): obj is HookInput {
 export function detectHarness(input: HookInput, config: Config): HarnessType | null {
   // If transcript_path hints at the harness, use that
   const tp = input.transcript_path ?? "";
-  if (tp.includes(`${sep}.claude${sep}`)) return "claude_code";
-  if (tp.includes(`${sep}.gemini${sep}`)) return "gemini_cli";
-  if (tp.includes(`${sep}.pi${sep}`)) return "pi_coding_agent";
+  if (/[/\\]\.claude[/\\]/.test(tp)) return "claude_code";
+  if (/[/\\]\.gemini[/\\]/.test(tp)) return "gemini_cli";
+  if (/[/\\]\.pi[/\\]/.test(tp)) return "pi_coding_agent";
 
   // Check environment variables
   if (process.env["CLAUDE_CODE_SESSION"]) return "claude_code";
@@ -88,7 +88,7 @@ export function resolveScope(cwd: string, config: Config): Scope {
   );
 
   for (const paiPath of expandedPaiPaths) {
-    if (cwd === paiPath || cwd.startsWith(paiPath + sep)) return "pai";
+    if (cwd === paiPath || cwd.startsWith(paiPath + "/")) return "pai";
   }
 
   return `project:${cwd}`;
@@ -145,7 +145,7 @@ export function signalsOutputDir(): string {
 
 export function signalsFilePath(date?: string): string {
   const d = date ?? new Date().toISOString().slice(0, 10); // YYYY-MM-DD
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(d)) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(d) || isNaN(new Date(d).getTime())) {
     throw new Error(`Invalid date format: expected YYYY-MM-DD, got "${d}"`);
   }
   return join(signalsOutputDir(), `${d}_signals.jsonl`);

--- a/src/lib/tagger.ts
+++ b/src/lib/tagger.ts
@@ -34,13 +34,15 @@ export function isHookInput(obj: unknown): obj is HookInput {
 
 // ── Harness detection ───────────────────────────────────────────────
 
+// Returns the detected harness type based on transcript_path, env vars, or config.
+// Note: does NOT check whether the harness is enabled — caller must verify via createAdapter.
 export function detectHarness(input: HookInput, config: Config): HarnessType | null {
   // If transcript_path hints at the harness, use that
   const tp = input.transcript_path ?? "";
   if (/[/\\]\.claude[/\\]/.test(tp)) return "claude_code";
   if (/[/\\]\.gemini[/\\]/.test(tp)) return "gemini_cli";
   // Note: /.pi/ is a short name that could match unrelated directories.
-  // This is acceptable since env-var checks above take priority for disambiguation.
+  // This is acceptable since transcript_path checks above take priority for disambiguation.
   if (/[/\\]\.pi[/\\]/.test(tp)) return "pi_coding_agent";
 
   // Check environment variables
@@ -58,7 +60,7 @@ export function detectHarness(input: HookInput, config: Config): HarnessType | n
 
 // ── Adapter factory ─────────────────────────────────────────────────
 
-function resolveEventsDir(dir: string): string {
+export function resolveEventsDir(dir: string): string {
   if (dir.startsWith("~/")) {
     return join(homedir(), dir.slice(2));
   }

--- a/src/lib/tagger.ts
+++ b/src/lib/tagger.ts
@@ -159,10 +159,11 @@ export function signalsFilePath(date?: string): string {
   return join(signalsOutputDir(), `${d}_signals.jsonl`);
 }
 
-export async function writeSignalRecord(record: SignalRecord): Promise<void> {
-  const dir = signalsOutputDir();
+export async function writeSignalRecord(record: SignalRecord, outputDir?: string): Promise<void> {
+  const dir = outputDir ?? signalsOutputDir();
   await mkdir(dir, { recursive: true });
   const date = record.timestamp.slice(0, 10);
+  const filePath = join(dir, `${date}_signals.jsonl`);
   const line = JSON.stringify(record) + "\n";
-  await appendFile(signalsFilePath(date), line, "utf-8");
+  await appendFile(filePath, line, "utf-8");
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,7 @@
 // ── Harness identification ──────────────────────────────────────────
 
-export type HarnessType = "claude_code" | "gemini_cli" | "pi_coding_agent";
+export const HARNESS_TYPES = ["claude_code", "gemini_cli", "pi_coding_agent"] as const;
+export type HarnessType = (typeof HARNESS_TYPES)[number];
 
 // ── Normalized events ──────────────────────────────────────────────
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -210,7 +210,7 @@ export interface HarnessConfig {
   events_dir: string;
 }
 
-export type HarnessesConfig = Record<string, HarnessConfig>;
+export type HarnessesConfig = Record<HarnessType, HarnessConfig>;
 
 export interface ScopeRulesConfig {
   pai_paths: string[];

--- a/src/signal-tagger.ts
+++ b/src/signal-tagger.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env bun
+
+import { loadConfig } from "./lib/config.js";
+import {
+  isHookInput,
+  detectHarness,
+  createAdapter,
+  buildSignalRecord,
+  writeSignalRecord,
+} from "./lib/tagger.js";
+
+async function main(): Promise<void> {
+  // Read stdin
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  const raw = Buffer.concat(chunks).toString("utf-8").trim();
+  if (!raw) return;
+
+  const parsed: unknown = JSON.parse(raw);
+  if (!isHookInput(parsed)) return;
+
+  const config = await loadConfig();
+  const harness = detectHarness(parsed, config);
+  if (!harness) return;
+
+  const adapter = createAdapter(harness, config);
+  if (!adapter) return;
+
+  const events = await adapter.getSessionEvents(parsed.session_id);
+  if (events.length === 0) return;
+
+  const cwd = parsed.cwd ?? events.find((e) => e.cwd)?.cwd ?? process.cwd();
+  const record = buildSignalRecord(parsed.session_id, events, config, cwd);
+
+  await writeSignalRecord(record);
+}
+
+// Silent failure — never block the coding agent
+main().catch(() => {});

--- a/src/signal-tagger.ts
+++ b/src/signal-tagger.ts
@@ -32,8 +32,8 @@ async function main(): Promise<void> {
   if (events.length === 0) return;
 
   const cwdFromEvents = parsed.cwd ?? events.find((e) => e.cwd)?.cwd;
-  if (!cwdFromEvents && process.env["ROBOREV_DEBUG"]) {
-    console.error("[signal-tagger] no cwd in hook input or events, falling back to process.cwd()");
+  if (!cwdFromEvents) {
+    console.error("[signal-tagger] warning: no cwd in hook input or events, falling back to process.cwd()");
   }
   const cwd = cwdFromEvents ?? process.cwd();
   const record = buildSignalRecord(parsed.session_id, events, config, cwd);

--- a/src/signal-tagger.ts
+++ b/src/signal-tagger.ts
@@ -38,4 +38,8 @@ async function main(): Promise<void> {
 }
 
 // Silent failure — never block the coding agent
-main().catch(() => {});
+main().catch((err) => {
+  if (process.env["ROBOREV_DEBUG"]) {
+    console.error("[signal-tagger]", err);
+  }
+});

--- a/src/signal-tagger.ts
+++ b/src/signal-tagger.ts
@@ -37,11 +37,11 @@ async function main(): Promise<void> {
   const events = await adapter.getSessionEvents(parsed.session_id);
   if (events.length === 0) return;
 
-  const cwdFromEvents = parsed.cwd ?? events.find((e) => e.cwd)?.cwd;
-  if (!cwdFromEvents) {
-    console.error("[signal-tagger] warning: no cwd in hook input or events, falling back to process.cwd()");
+  const cwd = parsed.cwd ?? events.find((e) => e.cwd)?.cwd;
+  if (!cwd) {
+    console.error("[signal-tagger] warning: no cwd in hook input or events, skipping record");
+    return;
   }
-  const cwd = cwdFromEvents ?? process.cwd();
   const record = buildSignalRecord(parsed.session_id, events, config, cwd);
 
   await writeSignalRecord(record);
@@ -49,7 +49,7 @@ async function main(): Promise<void> {
 
 // Silent failure — never block the coding agent
 main().catch((err) => {
-  if (process.env["ROBOREV_DEBUG"]) {
+  if (process.env["SIGNAL_TAGGER_DEBUG"]) {
     console.error("[signal-tagger]", err);
   }
 });

--- a/src/signal-tagger.ts
+++ b/src/signal-tagger.ts
@@ -31,7 +31,11 @@ async function main(): Promise<void> {
   const events = await adapter.getSessionEvents(parsed.session_id);
   if (events.length === 0) return;
 
-  const cwd = parsed.cwd ?? events.find((e) => e.cwd)?.cwd ?? process.cwd();
+  const cwdFromEvents = parsed.cwd ?? events.find((e) => e.cwd)?.cwd;
+  if (!cwdFromEvents && process.env["ROBOREV_DEBUG"]) {
+    console.error("[signal-tagger] no cwd in hook input or events, falling back to process.cwd()");
+  }
+  const cwd = cwdFromEvents ?? process.cwd();
   const record = buildSignalRecord(parsed.session_id, events, config, cwd);
 
   await writeSignalRecord(record);

--- a/src/signal-tagger.ts
+++ b/src/signal-tagger.ts
@@ -18,7 +18,13 @@ async function main(): Promise<void> {
   const raw = Buffer.concat(chunks).toString("utf-8").trim();
   if (!raw) return;
 
-  const parsed: unknown = JSON.parse(raw);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    console.error("[signal-tagger] warning: invalid JSON on stdin, ignoring");
+    return;
+  }
   if (!isHookInput(parsed)) return;
 
   const config = await loadConfig();

--- a/tests/signal-tagger.test.ts
+++ b/tests/signal-tagger.test.ts
@@ -69,10 +69,6 @@ function tsSec(secondOffset: number): string {
   return d.toISOString();
 }
 
-beforeEach(() => {
-  idCounter = 0;
-});
-
 // ── isHookInput ─────────────────────────────────────────────────────
 
 describe("isHookInput", () => {
@@ -212,6 +208,10 @@ describe("resolveScope", () => {
 // ── collectSignals ──────────────────────────────────────────────────
 
 describe("collectSignals", () => {
+  beforeEach(() => {
+    idCounter = 0;
+  });
+
   it("returns empty array for clean session", () => {
     const events = [
       makeEvent({ type: "session_start", timestamp: tsSec(0) }),
@@ -272,6 +272,10 @@ describe("collectSignals", () => {
 // ── buildSignalRecord ───────────────────────────────────────────────
 
 describe("buildSignalRecord", () => {
+  beforeEach(() => {
+    idCounter = 0;
+  });
+
   it("builds a complete SignalRecord", () => {
     const events = [
       makeEvent({ type: "session_start", timestamp: tsSec(0) }),

--- a/tests/signal-tagger.test.ts
+++ b/tests/signal-tagger.test.ts
@@ -69,6 +69,10 @@ function tsSec(secondOffset: number): string {
   return d.toISOString();
 }
 
+beforeEach(() => {
+  idCounter = 0;
+});
+
 // ── isHookInput ─────────────────────────────────────────────────────
 
 describe("isHookInput", () => {

--- a/tests/signal-tagger.test.ts
+++ b/tests/signal-tagger.test.ts
@@ -1,0 +1,380 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, mkdir, writeFile, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir, homedir } from "node:os";
+import type { Config, NormalizedEvent } from "../src/lib/types.js";
+import {
+  isHookInput,
+  detectHarness,
+  createAdapter,
+  resolveScope,
+  collectSignals,
+  buildSignalRecord,
+} from "../src/lib/tagger.js";
+
+// ── Test config ─────────────────────────────────────────────────────
+
+function makeConfig(overrides?: Partial<Config>): Config {
+  return {
+    version: "1.0.0",
+    tagger: {
+      rephrase_threshold: 3,
+      rephrase_similarity: 0.6,
+      tool_failure_cascade_min: 3,
+      context_churn_threshold: 2,
+      abandon_window_seconds: 120,
+      stall_threshold_seconds: 60,
+      retry_loop_min: 3,
+      retry_similarity: 0.7,
+    },
+    analyzer: {
+      model: "llama3.2",
+      ollama_url: "http://localhost:11434",
+      lookback_days: 7,
+      min_session_signals: 1,
+    },
+    actions: {
+      beads: { enabled: true, min_severity: "medium", min_frequency: 2, title_prefix: "[signals]" },
+      digest: { enabled: true, output_dir: "~/.claude/history/signals/digests" },
+      autofix: { enabled: true, min_severity: "high", min_frequency: 3, branch_prefix: "signals/fix-", branch_ttl_days: 14, allowed_tools: ["file_edit", "file_write"] },
+    },
+    harnesses: {
+      claude_code: { enabled: true, events_dir: "~/.claude/history/raw-outputs" },
+      gemini_cli: { enabled: false, events_dir: "" },
+      pi_coding_agent: { enabled: false, events_dir: "" },
+    },
+    scope_rules: {
+      pai_paths: ["~/.claude"],
+      ignore_paths: ["node_modules", ".git", "dist", "build"],
+    },
+    ...overrides,
+  };
+}
+
+let idCounter = 0;
+function makeEvent(overrides: Partial<NormalizedEvent> & { type: NormalizedEvent["type"] }): NormalizedEvent {
+  idCounter++;
+  return {
+    id: `evt-${idCounter}`,
+    timestamp: "2026-02-05T10:00:00.000Z",
+    harness: "claude_code",
+    session_id: "test-session",
+    ...overrides,
+  };
+}
+
+function tsSec(secondOffset: number): string {
+  const d = new Date("2026-02-05T10:00:00.000Z");
+  d.setSeconds(d.getSeconds() + secondOffset);
+  return d.toISOString();
+}
+
+// ── isHookInput ─────────────────────────────────────────────────────
+
+describe("isHookInput", () => {
+  it("accepts valid hook input", () => {
+    expect(isHookInput({ session_id: "abc-123" })).toBe(true);
+  });
+
+  it("accepts input with optional fields", () => {
+    expect(isHookInput({ session_id: "abc", cwd: "/foo", transcript_path: "/bar" })).toBe(true);
+  });
+
+  it("rejects null", () => {
+    expect(isHookInput(null)).toBe(false);
+  });
+
+  it("rejects non-object", () => {
+    expect(isHookInput("string")).toBe(false);
+  });
+
+  it("rejects missing session_id", () => {
+    expect(isHookInput({ cwd: "/foo" })).toBe(false);
+  });
+
+  it("rejects non-string session_id", () => {
+    expect(isHookInput({ session_id: 123 })).toBe(false);
+  });
+});
+
+// ── detectHarness ───────────────────────────────────────────────────
+
+describe("detectHarness", () => {
+  const config = makeConfig();
+
+  it("detects claude_code from transcript_path", () => {
+    expect(detectHarness({ session_id: "s", transcript_path: "/home/user/.claude/history/abc.jsonl" }, config)).toBe("claude_code");
+  });
+
+  it("detects gemini_cli from transcript_path", () => {
+    expect(detectHarness({ session_id: "s", transcript_path: "/home/user/.gemini/tmp/abc.json" }, config)).toBe("gemini_cli");
+  });
+
+  it("detects pi_coding_agent from transcript_path", () => {
+    expect(detectHarness({ session_id: "s", transcript_path: "/home/user/.pi/agent/sessions/abc.jsonl" }, config)).toBe("pi_coding_agent");
+  });
+
+  it("falls back to first enabled harness", () => {
+    const result = detectHarness({ session_id: "s" }, config);
+    expect(result).toBe("claude_code");
+  });
+
+  it("returns null when no harness enabled", () => {
+    const noHarness = makeConfig({
+      harnesses: {
+        claude_code: { enabled: false, events_dir: "" },
+        gemini_cli: { enabled: false, events_dir: "" },
+        pi_coding_agent: { enabled: false, events_dir: "" },
+      },
+    });
+    expect(detectHarness({ session_id: "s" }, noHarness)).toBeNull();
+  });
+});
+
+// ── createAdapter ───────────────────────────────────────────────────
+
+describe("createAdapter", () => {
+  it("creates ClaudeCodeAdapter", () => {
+    const config = makeConfig();
+    const adapter = createAdapter("claude_code", config);
+    expect(adapter).not.toBeNull();
+    expect(adapter!.getEventSource()).toBe("claude_code");
+  });
+
+  it("creates GeminiCliAdapter when enabled", () => {
+    const config = makeConfig({
+      harnesses: {
+        claude_code: { enabled: false, events_dir: "" },
+        gemini_cli: { enabled: true, events_dir: "/tmp/gemini" },
+        pi_coding_agent: { enabled: false, events_dir: "" },
+      },
+    });
+    const adapter = createAdapter("gemini_cli", config);
+    expect(adapter).not.toBeNull();
+    expect(adapter!.getEventSource()).toBe("gemini_cli");
+  });
+
+  it("creates PiCodingAgentAdapter when enabled", () => {
+    const config = makeConfig({
+      harnesses: {
+        claude_code: { enabled: false, events_dir: "" },
+        gemini_cli: { enabled: false, events_dir: "" },
+        pi_coding_agent: { enabled: true, events_dir: "/tmp/pi" },
+      },
+    });
+    const adapter = createAdapter("pi_coding_agent", config);
+    expect(adapter).not.toBeNull();
+    expect(adapter!.getEventSource()).toBe("pi_coding_agent");
+  });
+
+  it("returns null for disabled harness", () => {
+    const config = makeConfig({
+      harnesses: {
+        claude_code: { enabled: false, events_dir: "" },
+        gemini_cli: { enabled: false, events_dir: "" },
+        pi_coding_agent: { enabled: false, events_dir: "" },
+      },
+    });
+    expect(createAdapter("claude_code", config)).toBeNull();
+  });
+
+  it("expands ~ in events_dir", () => {
+    const config = makeConfig();
+    const adapter = createAdapter("claude_code", config);
+    // If it created successfully with ~/ path, expansion worked
+    expect(adapter).not.toBeNull();
+  });
+});
+
+// ── resolveScope ────────────────────────────────────────────────────
+
+describe("resolveScope", () => {
+  const config = makeConfig();
+
+  it("returns pai for paths under pai_paths", () => {
+    const home = homedir();
+    expect(resolveScope(`${home}/.claude/projects/foo`, config)).toBe("pai");
+  });
+
+  it("returns project scope for other paths", () => {
+    expect(resolveScope("/home/user/projects/myapp", config)).toBe("project:/home/user/projects/myapp");
+  });
+
+  it("returns project scope for non-matching cwd", () => {
+    expect(resolveScope("/tmp/test", config)).toBe("project:/tmp/test");
+  });
+});
+
+// ── collectSignals ──────────────────────────────────────────────────
+
+describe("collectSignals", () => {
+  it("returns empty array for clean session", () => {
+    const events = [
+      makeEvent({ type: "session_start", timestamp: tsSec(0) }),
+      makeEvent({ type: "user_prompt", message: "hello", timestamp: tsSec(1) }),
+      makeEvent({ type: "tool_result", tool_result: { success: true }, timestamp: tsSec(5) }),
+      makeEvent({ type: "session_end", timestamp: tsSec(10) }),
+    ];
+    const config = makeConfig();
+    const signals = collectSignals(events, config);
+    expect(signals).toEqual([]);
+  });
+
+  it("detects tool failure cascade", () => {
+    const events = [
+      makeEvent({ type: "session_start", timestamp: tsSec(0) }),
+      makeEvent({ type: "tool_result", tool_name: "shell_exec", tool_result: { success: false, error: "e1" }, timestamp: tsSec(1) }),
+      makeEvent({ type: "tool_result", tool_name: "shell_exec", tool_result: { success: false, error: "e2" }, timestamp: tsSec(2) }),
+      makeEvent({ type: "tool_result", tool_name: "shell_exec", tool_result: { success: false, error: "e3" }, timestamp: tsSec(3) }),
+      makeEvent({ type: "session_end", timestamp: tsSec(10) }),
+    ];
+    const config = makeConfig();
+    const signals = collectSignals(events, config);
+    expect(signals.some((s) => s.type === "tool_failure_cascade")).toBe(true);
+  });
+
+  it("detects context churn", () => {
+    const events = [
+      makeEvent({ type: "session_start", timestamp: tsSec(0) }),
+      makeEvent({ type: "compaction", timestamp: tsSec(10) }),
+      makeEvent({ type: "compaction", timestamp: tsSec(20) }),
+      makeEvent({ type: "session_end", timestamp: tsSec(30) }),
+    ];
+    const config = makeConfig();
+    const signals = collectSignals(events, config);
+    expect(signals.some((s) => s.type === "context_churn")).toBe(true);
+  });
+
+  it("detects multiple signals at once", () => {
+    const events = [
+      makeEvent({ type: "session_start", timestamp: tsSec(0) }),
+      makeEvent({ type: "compaction", timestamp: tsSec(1) }),
+      makeEvent({ type: "compaction", timestamp: tsSec(2) }),
+      makeEvent({ type: "permission_result", permission_granted: false, timestamp: tsSec(3) }),
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "e" }, timestamp: tsSec(4) }),
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "e" }, timestamp: tsSec(5) }),
+      makeEvent({ type: "tool_result", tool_result: { success: false, error: "e" }, timestamp: tsSec(6) }),
+      makeEvent({ type: "session_end", timestamp: tsSec(10) }),
+    ];
+    const config = makeConfig();
+    const signals = collectSignals(events, config);
+    expect(signals.length).toBeGreaterThanOrEqual(2);
+    const types = signals.map((s) => s.type);
+    expect(types).toContain("context_churn");
+    expect(types).toContain("permission_friction");
+  });
+});
+
+// ── buildSignalRecord ───────────────────────────────────────────────
+
+describe("buildSignalRecord", () => {
+  it("builds a complete SignalRecord", () => {
+    const events = [
+      makeEvent({ type: "session_start", timestamp: tsSec(0) }),
+      makeEvent({ type: "user_prompt", message: "fix the bug", timestamp: tsSec(1) }),
+      makeEvent({ type: "tool_use", tool_name: "file_read", tool_input: { file_path: "/src/main.ts" }, timestamp: tsSec(2) }),
+      makeEvent({ type: "tool_result", tool_name: "file_read", tool_result: { success: true }, timestamp: tsSec(3) }),
+      makeEvent({ type: "session_end", timestamp: tsSec(60) }),
+    ];
+    const config = makeConfig();
+    const record = buildSignalRecord("test-sess", events, config, "/home/user/project");
+
+    expect(record.session_id).toBe("test-sess");
+    expect(record.project).toBe("/home/user/project");
+    expect(record.scope).toBe("project:/home/user/project");
+    expect(record.timestamp).toBeTruthy();
+    expect(Array.isArray(record.signals)).toBe(true);
+    expect(record.facets.languages).toEqual(["TypeScript"]);
+    expect(record.facets.tools_used).toEqual(["file_read"]);
+    expect(record.facets.outcome).toBe("completed");
+    expect(record.facets.total_turns).toBe(1);
+  });
+
+  it("uses pai scope for pai paths", () => {
+    const events = [
+      makeEvent({ type: "session_start", timestamp: tsSec(0) }),
+      makeEvent({ type: "session_end", timestamp: tsSec(10) }),
+    ];
+    const config = makeConfig();
+    const home = homedir();
+    const record = buildSignalRecord("s", events, config, `${home}/.claude/hooks`);
+    expect(record.scope).toBe("pai");
+  });
+
+  it("includes detected signals", () => {
+    const events = [
+      makeEvent({ type: "session_start", timestamp: tsSec(0) }),
+      makeEvent({ type: "compaction", timestamp: tsSec(1) }),
+      makeEvent({ type: "compaction", timestamp: tsSec(2) }),
+      makeEvent({ type: "session_end", timestamp: tsSec(10) }),
+    ];
+    const config = makeConfig();
+    const record = buildSignalRecord("s", events, config, "/tmp/test");
+    expect(record.signals.length).toBeGreaterThan(0);
+    expect(record.signals[0]!.type).toBe("context_churn");
+  });
+});
+
+// ── End-to-end: script execution ────────────────────────────────────
+
+describe("signal-tagger script", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "tagger-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("exits silently with empty stdin", async () => {
+    const proc = Bun.spawn(["bun", "run", "src/signal-tagger.ts"], {
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    proc.stdin.end();
+    const exitCode = await proc.exited;
+    expect(exitCode).toBe(0);
+  });
+
+  it("exits silently with invalid JSON", async () => {
+    const proc = Bun.spawn(["bun", "run", "src/signal-tagger.ts"], {
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    proc.stdin.write("{bad json}");
+    proc.stdin.end();
+    const exitCode = await proc.exited;
+    expect(exitCode).toBe(0);
+  });
+
+  it("exits silently with missing session_id", async () => {
+    const proc = Bun.spawn(["bun", "run", "src/signal-tagger.ts"], {
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    proc.stdin.write(JSON.stringify({ cwd: "/tmp" }));
+    proc.stdin.end();
+    const exitCode = await proc.exited;
+    expect(exitCode).toBe(0);
+  });
+
+  it("exits silently when session has no events", async () => {
+    const proc = Bun.spawn(["bun", "run", "src/signal-tagger.ts"], {
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    proc.stdin.write(JSON.stringify({
+      session_id: "nonexistent-session",
+      transcript_path: "/home/user/.claude/history/abc.jsonl",
+    }));
+    proc.stdin.end();
+    const exitCode = await proc.exited;
+    expect(exitCode).toBe(0);
+  });
+});

--- a/tests/signal-tagger.test.ts
+++ b/tests/signal-tagger.test.ts
@@ -71,6 +71,10 @@ function tsSec(secondOffset: number): string {
   return d.toISOString();
 }
 
+beforeEach(() => {
+  idCounter = 0;
+});
+
 // ── isHookInput ─────────────────────────────────────────────────────
 
 describe("isHookInput", () => {
@@ -180,10 +184,11 @@ describe("createAdapter", () => {
     expect(createAdapter("claude_code", config)).toBeNull();
   });
 
-  it("expands ~ in events_dir", () => {
+  it("accepts config with ~/ events_dir without throwing", () => {
     const config = makeConfig();
+    // Note: tilde expansion is resolved at createAdapter time, but the path
+    // is only used when getSessionEvents reads from disk.
     const adapter = createAdapter("claude_code", config);
-    // If it created successfully with ~/ path, expansion worked
     expect(adapter).not.toBeNull();
   });
 });
@@ -210,10 +215,6 @@ describe("resolveScope", () => {
 // ── collectSignals ──────────────────────────────────────────────────
 
 describe("collectSignals", () => {
-  beforeEach(() => {
-    idCounter = 0;
-  });
-
   it("returns empty array for clean session", () => {
     const events = [
       makeEvent({ type: "session_start", timestamp: tsSec(0) }),
@@ -274,10 +275,6 @@ describe("collectSignals", () => {
 // ── buildSignalRecord ───────────────────────────────────────────────
 
 describe("buildSignalRecord", () => {
-  beforeEach(() => {
-    idCounter = 0;
-  });
-
   it("builds a complete SignalRecord", () => {
     const events = [
       makeEvent({ type: "session_start", timestamp: tsSec(0) }),
@@ -353,7 +350,6 @@ describe("writeSignalRecord integration", () => {
 
   beforeEach(async () => {
     tmpDir = await mkdtemp(join(tmpdir(), "tagger-write-"));
-    idCounter = 0;
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## Summary
- Adds `src/signal-tagger.ts` as executable SessionEnd hook entry point (`#!/usr/bin/env bun`)
- Extracts core tagger logic into `src/lib/tagger.ts` for testability: harness detection, adapter factory, scope resolution, signal collection, record building, JSONL output
- Reads stdin JSON (`session_id`, `cwd`, `transcript_path`), detects harness from transcript path or env vars, runs all 7 heuristics, writes `SignalRecord` to `~/.claude/history/signals/YYYY-MM-DD_signals.jsonl`
- Silent failure (exit 0) on any error — never blocks the coding agent
- Exports all tagger functions from `src/index.ts`

## Test plan
- [x] 30 tagger tests pass (`bun test tests/signal-tagger.test.ts`)
- [x] Full suite of 215 tests pass (`bun test`)
- [x] TypeScript typechecks clean (`bun run typecheck`)
- [x] Script exits 0 on empty stdin, invalid JSON, missing session_id, nonexistent session

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)