### PR TITLE
Implement Ollama client library

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,9 @@ export {
   writeSignalRecord,
 } from "./lib/tagger.js";
 
+export type { OllamaClient, OllamaClientOptions, OllamaGenerateOptions } from "./lib/ollama-client.js";
+export { createOllamaClient, OllamaError, OllamaConnectionError, OllamaParseError } from "./lib/ollama-client.js";
+
 export {
   levenshteinRatio,
   detectRephraseStorm,

--- a/src/lib/ollama-client.ts
+++ b/src/lib/ollama-client.ts
@@ -1,0 +1,163 @@
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface OllamaGenerateOptions {
+  model?: string;
+  format?: "json";
+}
+
+export interface OllamaClient {
+  generate(prompt: string, options?: OllamaGenerateOptions): Promise<string>;
+  generateJSON<T>(prompt: string, options?: { model?: string }): Promise<T>;
+  isAvailable(): Promise<boolean>;
+}
+
+export interface OllamaClientOptions {
+  baseUrl: string;
+  defaultModel: string;
+  timeoutMs?: number;
+  maxRetries?: number;
+}
+
+// ── Error types ─────────────────────────────────────────────────────
+
+export class OllamaError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "OllamaError";
+  }
+}
+
+export class OllamaConnectionError extends OllamaError {
+  constructor(cause?: unknown) {
+    super("Ollama is not reachable", cause);
+    this.name = "OllamaConnectionError";
+  }
+}
+
+export class OllamaParseError extends OllamaError {
+  constructor(
+    public readonly rawResponse: string,
+    cause?: unknown,
+  ) {
+    super("Failed to parse Ollama JSON response", cause);
+    this.name = "OllamaParseError";
+  }
+}
+
+// ── Implementation ──────────────────────────────────────────────────
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_RETRIES = 3;
+const BACKOFF_BASE_MS = 1000;
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function createOllamaClient(options: OllamaClientOptions): OllamaClient {
+  const baseUrl = options.baseUrl.replace(/\/+$/, "");
+  const defaultModel = options.defaultModel;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+
+  async function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      return await fetch(url, { ...init, signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async function generate(prompt: string, options?: OllamaGenerateOptions): Promise<string> {
+    const model = options?.model ?? defaultModel;
+    const body: Record<string, unknown> = {
+      model,
+      prompt,
+      stream: false,
+    };
+    if (options?.format === "json") {
+      body["format"] = "json";
+    }
+
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      if (attempt > 0) {
+        await sleep(BACKOFF_BASE_MS * Math.pow(2, attempt - 1));
+      }
+
+      try {
+        const response = await fetchWithTimeout(`${baseUrl}/api/generate`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+
+        if (!response.ok) {
+          throw new OllamaError(`Ollama returned HTTP ${response.status}: ${await response.text()}`);
+        }
+
+        const data = (await response.json()) as Record<string, unknown>;
+        const text = data["response"];
+        if (typeof text !== "string") {
+          throw new OllamaError("Ollama response missing 'response' field");
+        }
+
+        return text;
+      } catch (err) {
+        lastError = err;
+
+        // Don't retry on non-retryable errors
+        if (err instanceof OllamaError && !(err instanceof OllamaConnectionError)) {
+          // HTTP errors that aren't connection issues — retry
+        }
+
+        // Connection errors — check if it's a fetch/abort issue
+        if (err instanceof TypeError || (err instanceof DOMException && err.name === "AbortError")) {
+          lastError = new OllamaConnectionError(err);
+        }
+      }
+    }
+
+    throw lastError instanceof OllamaError
+      ? lastError
+      : new OllamaConnectionError(lastError);
+  }
+
+  async function generateJSON<T>(prompt: string, options?: { model?: string }): Promise<T> {
+    const opts: OllamaGenerateOptions = { format: "json" };
+    if (options?.model) opts.model = options.model;
+
+    const raw = await generate(prompt, opts);
+
+    try {
+      return JSON.parse(raw) as T;
+    } catch (err) {
+      // Retry once for JSON parse failures
+      try {
+        const retry = await generate(prompt, opts);
+        return JSON.parse(retry) as T;
+      } catch (retryErr) {
+        throw new OllamaParseError(raw, retryErr);
+      }
+    }
+  }
+
+  async function isAvailable(): Promise<boolean> {
+    try {
+      const response = await fetchWithTimeout(`${baseUrl}/api/tags`, {
+        method: "GET",
+      });
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  return { generate, generateJSON, isAvailable };
+}

--- a/tests/ollama-client.test.ts
+++ b/tests/ollama-client.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+  createOllamaClient,
+  OllamaConnectionError,
+  OllamaParseError,
+  OllamaError,
+} from "../src/lib/ollama-client.js";
+
+// ── Mock HTTP server ────────────────────────────────────────────────
+
+type Handler = (req: Request) => Response | Promise<Response>;
+
+let server: ReturnType<typeof Bun.serve> | null = null;
+let handler: Handler = () => new Response("not configured", { status: 500 });
+
+function startServer(h: Handler): string {
+  handler = h;
+  server = Bun.serve({
+    port: 0,
+    fetch: (req) => handler(req),
+  });
+  return `http://localhost:${server.port}`;
+}
+
+function stopServer(): void {
+  if (server) {
+    server.stop(true);
+    server = null;
+  }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe("OllamaClient", () => {
+  afterEach(() => {
+    stopServer();
+  });
+
+  // ── isAvailable ─────────────────────────────────────────────
+
+  describe("isAvailable", () => {
+    it("returns true when Ollama is running", async () => {
+      const url = startServer((req) => {
+        if (new URL(req.url).pathname === "/api/tags") {
+          return new Response(JSON.stringify({ models: [] }), { status: 200 });
+        }
+        return new Response("not found", { status: 404 });
+      });
+
+      const client = createOllamaClient({ baseUrl: url, defaultModel: "llama3.2" });
+      expect(await client.isAvailable()).toBe(true);
+    });
+
+    it("returns false when Ollama is not reachable", async () => {
+      const client = createOllamaClient({
+        baseUrl: "http://localhost:19999",
+        defaultModel: "llama3.2",
+        timeoutMs: 500,
+      });
+      expect(await client.isAvailable()).toBe(false);
+    });
+
+    it("returns false when Ollama returns error", async () => {
+      const url = startServer(() => new Response("error", { status: 500 }));
+      const client = createOllamaClient({ baseUrl: url, defaultModel: "llama3.2" });
+      expect(await client.isAvailable()).toBe(false);
+    });
+  });
+
+  // ── generate ────────────────────────────────────────────────
+
+  describe("generate", () => {
+    it("sends correct request body", async () => {
+      let capturedBody: Record<string, unknown> | null = null;
+
+      const url = startServer(async (req) => {
+        capturedBody = (await req.json()) as Record<string, unknown>;
+        return Response.json({ response: "hello" });
+      });
+
+      const client = createOllamaClient({ baseUrl: url, defaultModel: "llama3.2" });
+      await client.generate("test prompt");
+
+      expect(capturedBody).not.toBeNull();
+      expect(capturedBody!["model"]).toBe("llama3.2");
+      expect(capturedBody!["prompt"]).toBe("test prompt");
+      expect(capturedBody!["stream"]).toBe(false);
+    });
+
+    it("uses custom model when specified", async () => {
+      let capturedBody: Record<string, unknown> | null = null;
+
+      const url = startServer(async (req) => {
+        capturedBody = (await req.json()) as Record<string, unknown>;
+        return Response.json({ response: "hi" });
+      });
+
+      const client = createOllamaClient({ baseUrl: url, defaultModel: "llama3.2" });
+      await client.generate("test", { model: "mistral" });
+
+      expect(capturedBody!["model"]).toBe("mistral");
+    });
+
+    it("includes format json when specified", async () => {
+      let capturedBody: Record<string, unknown> | null = null;
+
+      const url = startServer(async (req) => {
+        capturedBody = (await req.json()) as Record<string, unknown>;
+        return Response.json({ response: "{}" });
+      });
+
+      const client = createOllamaClient({ baseUrl: url, defaultModel: "llama3.2" });
+      await client.generate("test", { format: "json" });
+
+      expect(capturedBody!["format"]).toBe("json");
+    });
+
+    it("returns response text", async () => {
+      const url = startServer(() => Response.json({ response: "the answer is 42" }));
+      const client = createOllamaClient({ baseUrl: url, defaultModel: "llama3.2" });
+      const result = await client.generate("what is the answer?");
+      expect(result).toBe("the answer is 42");
+    });
+
+    it("retries on failure then succeeds", async () => {
+      let attempts = 0;
+
+      const url = startServer(() => {
+        attempts++;
+        if (attempts < 3) {
+          return new Response("error", { status: 500 });
+        }
+        return Response.json({ response: "success after retries" });
+      });
+
+      const client = createOllamaClient({
+        baseUrl: url,
+        defaultModel: "llama3.2",
+        maxRetries: 3,
+      });
+      const result = await client.generate("test");
+      expect(result).toBe("success after retries");
+      expect(attempts).toBe(3);
+    });
+
+    it("throws after exhausting retries", async () => {
+      const url = startServer(() => new Response("error", { status: 500 }));
+
+      const client = createOllamaClient({
+        baseUrl: url,
+        defaultModel: "llama3.2",
+        maxRetries: 2,
+      });
+
+      await expect(client.generate("test")).rejects.toThrow(OllamaError);
+    });
+
+    it("throws OllamaConnectionError when server unreachable", async () => {
+      const client = createOllamaClient({
+        baseUrl: "http://localhost:19999",
+        defaultModel: "llama3.2",
+        maxRetries: 1,
+        timeoutMs: 500,
+      });
+
+      await expect(client.generate("test")).rejects.toThrow(OllamaConnectionError);
+    });
+
+    it("throws when response is missing 'response' field", async () => {
+      const url = startServer(() => Response.json({ bad_field: "oops" }));
+
+      const client = createOllamaClient({
+        baseUrl: url,
+        defaultModel: "llama3.2",
+        maxRetries: 1,
+      });
+
+      await expect(client.generate("test")).rejects.toThrow("missing 'response' field");
+    });
+  });
+
+  // ── generateJSON ────────────────────────────────────────────
+
+  describe("generateJSON", () => {
+    it("parses JSON response", async () => {
+      const url = startServer(() =>
+        Response.json({ response: JSON.stringify({ answer: 42, items: ["a", "b"] }) }),
+      );
+
+      const client = createOllamaClient({ baseUrl: url, defaultModel: "llama3.2" });
+      const result = await client.generateJSON<{ answer: number; items: string[] }>("give json");
+      expect(result.answer).toBe(42);
+      expect(result.items).toEqual(["a", "b"]);
+    });
+
+    it("requests json format", async () => {
+      let capturedBody: Record<string, unknown> | null = null;
+
+      const url = startServer(async (req) => {
+        capturedBody = (await req.json()) as Record<string, unknown>;
+        return Response.json({ response: "{}" });
+      });
+
+      const client = createOllamaClient({ baseUrl: url, defaultModel: "llama3.2" });
+      await client.generateJSON("test");
+
+      expect(capturedBody!["format"]).toBe("json");
+    });
+
+    it("retries once on JSON parse failure then succeeds", async () => {
+      let calls = 0;
+
+      const url = startServer(() => {
+        calls++;
+        if (calls <= 1) {
+          // First call: return invalid JSON in the response field
+          return Response.json({ response: "not valid json" });
+        }
+        // Retry: return valid JSON
+        return Response.json({ response: JSON.stringify({ ok: true }) });
+      });
+
+      const client = createOllamaClient({
+        baseUrl: url,
+        defaultModel: "llama3.2",
+        maxRetries: 3,
+      });
+      const result = await client.generateJSON<{ ok: boolean }>("test");
+      expect(result.ok).toBe(true);
+    });
+
+    it("throws OllamaParseError when JSON is persistently invalid", async () => {
+      const url = startServer(() =>
+        Response.json({ response: "this is not json at all" }),
+      );
+
+      const client = createOllamaClient({
+        baseUrl: url,
+        defaultModel: "llama3.2",
+        maxRetries: 3,
+      });
+
+      try {
+        await client.generateJSON("test");
+        expect(true).toBe(false); // should not reach here
+      } catch (err) {
+        expect(err).toBeInstanceOf(OllamaParseError);
+        expect((err as OllamaParseError).rawResponse).toBe("this is not json at all");
+      }
+    });
+
+    it("uses custom model", async () => {
+      let capturedBody: Record<string, unknown> | null = null;
+
+      const url = startServer(async (req) => {
+        capturedBody = (await req.json()) as Record<string, unknown>;
+        return Response.json({ response: "{}" });
+      });
+
+      const client = createOllamaClient({ baseUrl: url, defaultModel: "llama3.2" });
+      await client.generateJSON("test", { model: "codellama" });
+
+      expect(capturedBody!["model"]).toBe("codellama");
+    });
+  });
+
+  // ── Edge cases ──────────────────────────────────────────────
+
+  describe("edge cases", () => {
+    it("strips trailing slashes from baseUrl", async () => {
+      let requestUrl = "";
+
+      const url = startServer((req) => {
+        requestUrl = req.url;
+        return Response.json({ response: "ok" });
+      });
+
+      const client = createOllamaClient({ baseUrl: url + "///", defaultModel: "llama3.2" });
+      await client.generate("test");
+
+      expect(requestUrl).toContain("/api/generate");
+      expect(requestUrl).not.toContain("////api");
+    });
+
+    it("handles empty response string", async () => {
+      const url = startServer(() => Response.json({ response: "" }));
+      const client = createOllamaClient({ baseUrl: url, defaultModel: "llama3.2" });
+      const result = await client.generate("test");
+      expect(result).toBe("");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/lib/ollama-client.ts` — thin HTTP wrapper for Ollama's `/api/generate` endpoint
- `generate(prompt, options?)` — sends prompts, returns raw text response
- `generateJSON<T>(prompt, options?)` — requests JSON format, parses response with one retry on parse failure
- `isAvailable()` — checks if Ollama is running via `/api/tags`
- Exponential backoff retry (1s, 2s, 4s) with configurable max retries and timeout (default 30s)
- Typed error hierarchy: `OllamaError`, `OllamaConnectionError`, `OllamaParseError`
- No external dependencies (uses native fetch)
- Exported from `src/index.ts`

## Test plan
- [x] 18 Ollama client tests pass with real Bun HTTP mock server (`bun test tests/ollama-client.test.ts`)
- [x] Full suite of 243 tests pass (`bun test`)
- [x] TypeScript typechecks clean (`bun run typecheck`)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)