### PR TITLE
Implement pattern analyzer (daily batch)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,18 @@ export {
 export type { OllamaClient, OllamaClientOptions, OllamaGenerateOptions } from "./lib/ollama-client.js";
 export { createOllamaClient, OllamaError, OllamaConnectionError, OllamaParseError } from "./lib/ollama-client.js";
 
+export type { DailyTrend, AnalysisResult } from "./lib/pattern-analyzer.js";
+export {
+  dateRange,
+  loadSignalRecords,
+  groupByScope,
+  computeDailyTrends,
+  classifyTrend,
+  buildPrompt,
+  analyzeScope,
+  runAnalysis,
+} from "./lib/pattern-analyzer.js";
+
 export {
   levenshteinRatio,
   detectRephraseStorm,

--- a/src/lib/pattern-analyzer.ts
+++ b/src/lib/pattern-analyzer.ts
@@ -1,0 +1,322 @@
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import type {
+  Config,
+  PatternAnalysis,
+  PatternTrend,
+  Scope,
+  SignalRecord,
+} from "./types.js";
+import type { OllamaClient } from "./ollama-client.js";
+import { signalsOutputDir } from "./tagger.js";
+
+// ── Signal loading ──────────────────────────────────────────────────
+
+export function dateRange(lookbackDays: number, referenceDate?: Date): string[] {
+  const ref = referenceDate ?? new Date();
+  const dates: string[] = [];
+  for (let i = 0; i < lookbackDays; i++) {
+    const d = new Date(ref);
+    d.setDate(d.getDate() - i);
+    dates.push(d.toISOString().slice(0, 10));
+  }
+  return dates.reverse();
+}
+
+export async function loadSignalRecords(
+  days: string[],
+  dir?: string,
+): Promise<SignalRecord[]> {
+  const signalsDir = dir ?? signalsOutputDir();
+  const records: SignalRecord[] = [];
+
+  let files: string[];
+  try {
+    files = await readdir(signalsDir);
+  } catch {
+    return records;
+  }
+
+  const daySet = new Set(days);
+  const matching = files.filter((f) => {
+    const date = f.replace(/_signals\.jsonl$/, "");
+    return daySet.has(date);
+  });
+
+  for (const file of matching) {
+    let content: string;
+    try {
+      content = await readFile(join(signalsDir, file), "utf-8");
+    } catch {
+      continue;
+    }
+
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const record = JSON.parse(trimmed) as SignalRecord;
+        if (record.session_id && record.scope) {
+          records.push(record);
+        }
+      } catch {
+        // skip malformed lines
+      }
+    }
+  }
+
+  return records;
+}
+
+// ── Grouping ────────────────────────────────────────────────────────
+
+export function groupByScope(records: SignalRecord[]): Map<Scope, SignalRecord[]> {
+  const groups = new Map<Scope, SignalRecord[]>();
+  for (const record of records) {
+    const existing = groups.get(record.scope);
+    if (existing) {
+      existing.push(record);
+    } else {
+      groups.set(record.scope, [record]);
+    }
+  }
+  return groups;
+}
+
+// ── Trend computation ───────────────────────────────────────────────
+
+export interface DailyTrend {
+  date: string;
+  counts: Record<string, number>;
+}
+
+export function computeDailyTrends(
+  records: SignalRecord[],
+  days: string[],
+): DailyTrend[] {
+  const dayMap = new Map<string, Record<string, number>>();
+  for (const day of days) {
+    dayMap.set(day, {});
+  }
+
+  for (const record of records) {
+    const date = record.timestamp.slice(0, 10);
+    const counts = dayMap.get(date);
+    if (!counts) continue;
+
+    for (const signal of record.signals) {
+      counts[signal.type] = (counts[signal.type] ?? 0) + signal.count;
+    }
+  }
+
+  return days.map((date) => ({
+    date,
+    counts: dayMap.get(date) ?? {},
+  }));
+}
+
+export function classifyTrend(
+  signalType: string,
+  trends: DailyTrend[],
+): PatternTrend {
+  const counts = trends.map((t) => t.counts[signalType] ?? 0);
+  const activeDays = counts.filter((c) => c > 0).length;
+
+  if (activeDays === 0) return "new";
+
+  // Check if it only appeared in the most recent day
+  const nonZeroIndices = counts
+    .map((c, i) => (c > 0 ? i : -1))
+    .filter((i) => i >= 0);
+  if (nonZeroIndices.length === 1 && nonZeroIndices[0] === counts.length - 1) {
+    return "new";
+  }
+
+  if (activeDays < 3) return "new";
+
+  // Compare first half vs second half
+  const mid = Math.floor(counts.length / 2);
+  const firstHalf = counts.slice(0, mid).reduce((a, b) => a + b, 0);
+  const secondHalf = counts.slice(mid).reduce((a, b) => a + b, 0);
+
+  if (secondHalf > firstHalf * 1.2) return "increasing";
+  if (secondHalf < firstHalf * 0.8) return "decreasing";
+  return "stable";
+}
+
+// ── Prompt building ─────────────────────────────────────────────────
+
+export function buildPrompt(
+  scope: Scope,
+  records: SignalRecord[],
+  trends: DailyTrend[],
+): string {
+  const signalSummary = records.flatMap((r) =>
+    r.signals.map((s) => ({
+      session_id: r.session_id,
+      type: s.type,
+      severity: s.severity,
+      count: s.count,
+      context: s.context,
+    })),
+  );
+
+  const trendTable = trends.map((t) => {
+    const entries = Object.entries(t.counts)
+      .map(([type, count]) => `${type}=${count}`)
+      .join(", ");
+    return `${t.date}: ${entries || "(none)"}`;
+  });
+
+  // Collect unique signal types for trend classification
+  const signalTypes = new Set<string>();
+  for (const record of records) {
+    for (const signal of record.signals) {
+      signalTypes.add(signal.type);
+    }
+  }
+
+  const trendClassifications: Record<string, PatternTrend> = {};
+  for (const type of signalTypes) {
+    trendClassifications[type] = classifyTrend(type, trends);
+  }
+
+  return `You are a coding agent friction analyst. Analyze these signals from scope "${scope}" and produce a structured JSON response.
+
+## Signals (${signalSummary.length} total from ${records.length} sessions)
+
+${JSON.stringify(signalSummary, null, 2)}
+
+## Daily Trend Table (last ${trends.length} days)
+
+${trendTable.join("\n")}
+
+## Pre-computed Trend Classifications
+
+${JSON.stringify(trendClassifications, null, 2)}
+
+## Instructions
+
+Produce a JSON object matching this exact schema:
+
+{
+  "patterns": [
+    {
+      "id": "pat-YYYYMMDD-NNN",
+      "type": "recurring_friction" | "new_friction" | "regression",
+      "scope": "${scope}",
+      "description": "...",
+      "severity": "high" | "medium" | "low",
+      "frequency": <number of sessions affected>,
+      "trend": "increasing" | "stable" | "decreasing" | "new",
+      "root_cause_hypothesis": "...",
+      "suggested_fix": "...",
+      "auto_fixable": true | false,
+      "fix_scope": "pai" | "project",
+      "affected_files": ["..."]
+    }
+  ],
+  "delight_patterns": [
+    {
+      "description": "...",
+      "insight": "..."
+    }
+  ],
+  "summary": "Brief overall summary of friction patterns"
+}
+
+Rules:
+- Group related signals into patterns (e.g. repeated tool_failure_cascade on the same tool)
+- Use the pre-computed trend classifications
+- Set auto_fixable=true only for patterns that could be fixed by modifying config or CLAUDE.md
+- Include delight_patterns for things that work well (low failure rates, fast sessions)
+- Keep the summary under 200 words
+- Return ONLY valid JSON, no markdown fences or extra text`;
+}
+
+// ── Analysis execution ──────────────────────────────────────────────
+
+export interface AnalysisResult {
+  scope: Scope;
+  analysis: PatternAnalysis;
+  skipped: boolean;
+}
+
+const EMPTY_ANALYSIS: PatternAnalysis = {
+  patterns: [],
+  delight_patterns: [],
+  summary: "",
+};
+
+function isPatternAnalysis(obj: unknown): obj is PatternAnalysis {
+  if (typeof obj !== "object" || obj === null) return false;
+  const o = obj as Record<string, unknown>;
+  return Array.isArray(o["patterns"]) && typeof o["summary"] === "string";
+}
+
+export async function analyzeScope(
+  scope: Scope,
+  records: SignalRecord[],
+  trends: DailyTrend[],
+  client: OllamaClient,
+  config: Config,
+  warn?: (msg: string) => void,
+): Promise<AnalysisResult> {
+  // Filter records with signals meeting minimum threshold
+  const withSignals = records.filter((r) => r.signals.length >= config.analyzer.min_session_signals);
+  if (withSignals.length === 0) {
+    return { scope, analysis: EMPTY_ANALYSIS, skipped: true };
+  }
+
+  const available = await client.isAvailable();
+  if (!available) {
+    warn?.("Ollama is not available, skipping pattern analysis");
+    return { scope, analysis: EMPTY_ANALYSIS, skipped: true };
+  }
+
+  const prompt = buildPrompt(scope, withSignals, trends);
+
+  try {
+    const result = await client.generateJSON<PatternAnalysis>(prompt, {
+      model: config.analyzer.model,
+    });
+
+    if (!isPatternAnalysis(result)) {
+      warn?.(`Ollama returned unexpected shape for scope "${scope}"`);
+      return { scope, analysis: EMPTY_ANALYSIS, skipped: true };
+    }
+
+    return { scope, analysis: result, skipped: false };
+  } catch (err) {
+    warn?.(`Pattern analysis failed for scope "${scope}": ${err}`);
+    return { scope, analysis: EMPTY_ANALYSIS, skipped: true };
+  }
+}
+
+export async function runAnalysis(
+  config: Config,
+  client: OllamaClient,
+  options?: {
+    signalsDir?: string;
+    referenceDate?: Date;
+    warn?: (msg: string) => void;
+  },
+): Promise<AnalysisResult[]> {
+  const days = dateRange(config.analyzer.lookback_days, options?.referenceDate);
+  const records = await loadSignalRecords(days, options?.signalsDir);
+
+  if (records.length === 0) {
+    return [];
+  }
+
+  const groups = groupByScope(records);
+  const results: AnalysisResult[] = [];
+
+  for (const [scope, scopeRecords] of groups) {
+    const trends = computeDailyTrends(scopeRecords, days);
+    const result = await analyzeScope(scope, scopeRecords, trends, client, config, options?.warn);
+    results.push(result);
+  }
+
+  return results;
+}

--- a/src/pattern-analyzer.ts
+++ b/src/pattern-analyzer.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env bun
+
+import { loadConfig } from "./lib/config.js";
+import { createOllamaClient } from "./lib/ollama-client.js";
+import { runAnalysis } from "./lib/pattern-analyzer.js";
+
+async function main(): Promise<void> {
+  const config = await loadConfig();
+
+  const client = createOllamaClient({
+    baseUrl: config.analyzer.ollama_url,
+    defaultModel: config.analyzer.model,
+  });
+
+  const results = await runAnalysis(config, client, {
+    warn: console.warn,
+  });
+
+  // Output results as JSON to stdout for downstream consumption
+  const output = {
+    timestamp: new Date().toISOString(),
+    results: results.map((r) => ({
+      scope: r.scope,
+      skipped: r.skipped,
+      patterns_count: r.analysis.patterns.length,
+      analysis: r.analysis,
+    })),
+  };
+
+  console.log(JSON.stringify(output, null, 2));
+}
+
+main().catch((err) => {
+  console.error("pattern-analyzer failed:", err);
+  process.exit(1);
+});

--- a/tests/pattern-analyzer.test.ts
+++ b/tests/pattern-analyzer.test.ts
@@ -1,0 +1,489 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { Config, SignalRecord, PatternAnalysis } from "../src/lib/types.js";
+import type { OllamaClient } from "../src/lib/ollama-client.js";
+import {
+  dateRange,
+  loadSignalRecords,
+  groupByScope,
+  computeDailyTrends,
+  classifyTrend,
+  buildPrompt,
+  analyzeScope,
+  runAnalysis,
+} from "../src/lib/pattern-analyzer.js";
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function makeConfig(overrides?: Partial<Config>): Config {
+  return {
+    version: "1.0.0",
+    tagger: {
+      rephrase_threshold: 3,
+      rephrase_similarity: 0.6,
+      tool_failure_cascade_min: 3,
+      context_churn_threshold: 2,
+      abandon_window_seconds: 120,
+      stall_threshold_seconds: 60,
+      retry_loop_min: 3,
+      retry_similarity: 0.7,
+    },
+    analyzer: {
+      model: "llama3.2",
+      ollama_url: "http://localhost:11434",
+      lookback_days: 7,
+      min_session_signals: 1,
+    },
+    actions: {
+      beads: { enabled: true, min_severity: "medium", min_frequency: 2, title_prefix: "[signals]" },
+      digest: { enabled: true, output_dir: "~/.claude/history/signals/digests" },
+      autofix: { enabled: true, min_severity: "high", min_frequency: 3, branch_prefix: "signals/fix-", branch_ttl_days: 14, allowed_tools: ["file_edit", "file_write"] },
+    },
+    harnesses: {
+      claude_code: { enabled: true, events_dir: "~/.claude/history/raw-outputs" },
+      gemini_cli: { enabled: false, events_dir: "" },
+      pi_coding_agent: { enabled: false, events_dir: "" },
+    },
+    scope_rules: {
+      pai_paths: ["~/.claude"],
+      ignore_paths: ["node_modules", ".git", "dist", "build"],
+    },
+    ...overrides,
+  };
+}
+
+function makeSignalRecord(overrides?: Partial<SignalRecord>): SignalRecord {
+  return {
+    session_id: "sess-1",
+    timestamp: "2026-02-05T10:00:00.000Z",
+    project: "/home/user/project",
+    scope: "project:/home/user/project",
+    signals: [
+      {
+        type: "tool_failure_cascade",
+        severity: "medium",
+        count: 3,
+        context: "3 consecutive tool failures",
+        evidence: { event_indices: [1, 2, 3] },
+      },
+    ],
+    facets: {
+      languages: ["TypeScript"],
+      tools_used: ["file_edit", "shell_exec"],
+      tool_failure_rate: 0.3,
+      session_duration_min: 15,
+      total_turns: 5,
+      outcome: "completed",
+    },
+    ...overrides,
+  };
+}
+
+function mockOllamaClient(response?: PatternAnalysis): OllamaClient {
+  const defaultResponse: PatternAnalysis = response ?? {
+    patterns: [{
+      id: "pat-20260205-001",
+      type: "recurring_friction",
+      scope: "project:/home/user/project",
+      description: "Repeated shell failures",
+      severity: "medium",
+      frequency: 3,
+      trend: "stable",
+      root_cause_hypothesis: "Missing dependency",
+      suggested_fix: "Install the dependency",
+      auto_fixable: false,
+      fix_scope: "project",
+      affected_files: [],
+    }],
+    delight_patterns: [],
+    summary: "Some friction detected",
+  };
+
+  return {
+    generate: async () => JSON.stringify(defaultResponse),
+    generateJSON: async <T>() => defaultResponse as unknown as T,
+    isAvailable: async () => true,
+  };
+}
+
+function mockUnavailableClient(): OllamaClient {
+  return {
+    generate: async () => { throw new Error("unavailable"); },
+    generateJSON: async () => { throw new Error("unavailable"); },
+    isAvailable: async () => false,
+  };
+}
+
+// ── dateRange ───────────────────────────────────────────────────────
+
+describe("dateRange", () => {
+  it("generates correct number of dates", () => {
+    const dates = dateRange(7, new Date("2026-02-07T12:00:00Z"));
+    expect(dates).toHaveLength(7);
+  });
+
+  it("dates are in ascending order", () => {
+    const dates = dateRange(3, new Date("2026-02-07T12:00:00Z"));
+    expect(dates).toEqual(["2026-02-05", "2026-02-06", "2026-02-07"]);
+  });
+
+  it("handles single day", () => {
+    const dates = dateRange(1, new Date("2026-02-07T12:00:00Z"));
+    expect(dates).toEqual(["2026-02-07"]);
+  });
+});
+
+// ── loadSignalRecords ───────────────────────────────────────────────
+
+describe("loadSignalRecords", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "analyzer-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty when dir does not exist", async () => {
+    const records = await loadSignalRecords(["2026-02-05"], "/nonexistent");
+    expect(records).toEqual([]);
+  });
+
+  it("loads records from matching date files", async () => {
+    const record = makeSignalRecord();
+    await writeFile(
+      join(tmpDir, "2026-02-05_signals.jsonl"),
+      JSON.stringify(record) + "\n",
+    );
+
+    const records = await loadSignalRecords(["2026-02-05"], tmpDir);
+    expect(records).toHaveLength(1);
+    expect(records[0]!.session_id).toBe("sess-1");
+  });
+
+  it("ignores non-matching date files", async () => {
+    await writeFile(
+      join(tmpDir, "2026-02-04_signals.jsonl"),
+      JSON.stringify(makeSignalRecord()) + "\n",
+    );
+
+    const records = await loadSignalRecords(["2026-02-05"], tmpDir);
+    expect(records).toEqual([]);
+  });
+
+  it("loads multiple records from multiple files", async () => {
+    await writeFile(
+      join(tmpDir, "2026-02-05_signals.jsonl"),
+      JSON.stringify(makeSignalRecord({ session_id: "s1" })) + "\n" +
+      JSON.stringify(makeSignalRecord({ session_id: "s2" })) + "\n",
+    );
+    await writeFile(
+      join(tmpDir, "2026-02-06_signals.jsonl"),
+      JSON.stringify(makeSignalRecord({ session_id: "s3", timestamp: "2026-02-06T10:00:00.000Z" })) + "\n",
+    );
+
+    const records = await loadSignalRecords(["2026-02-05", "2026-02-06"], tmpDir);
+    expect(records).toHaveLength(3);
+  });
+
+  it("skips malformed JSONL lines", async () => {
+    await writeFile(
+      join(tmpDir, "2026-02-05_signals.jsonl"),
+      "{bad json\n" + JSON.stringify(makeSignalRecord()) + "\n",
+    );
+
+    const records = await loadSignalRecords(["2026-02-05"], tmpDir);
+    expect(records).toHaveLength(1);
+  });
+});
+
+// ── groupByScope ────────────────────────────────────────────────────
+
+describe("groupByScope", () => {
+  it("groups records by scope", () => {
+    const records = [
+      makeSignalRecord({ scope: "pai" }),
+      makeSignalRecord({ scope: "project:/a" }),
+      makeSignalRecord({ scope: "pai" }),
+      makeSignalRecord({ scope: "project:/b" }),
+    ];
+
+    const groups = groupByScope(records);
+    expect(groups.size).toBe(3);
+    expect(groups.get("pai")!.length).toBe(2);
+    expect(groups.get("project:/a")!.length).toBe(1);
+    expect(groups.get("project:/b")!.length).toBe(1);
+  });
+
+  it("returns empty map for empty input", () => {
+    expect(groupByScope([]).size).toBe(0);
+  });
+});
+
+// ── computeDailyTrends ──────────────────────────────────────────────
+
+describe("computeDailyTrends", () => {
+  it("computes counts per day per signal type", () => {
+    const records = [
+      makeSignalRecord({
+        timestamp: "2026-02-05T10:00:00.000Z",
+        signals: [
+          { type: "tool_failure_cascade", severity: "medium", count: 3, context: "", evidence: { event_indices: [] } },
+          { type: "context_churn", severity: "low", count: 2, context: "", evidence: { event_indices: [] } },
+        ],
+      }),
+      makeSignalRecord({
+        timestamp: "2026-02-05T14:00:00.000Z",
+        signals: [
+          { type: "tool_failure_cascade", severity: "high", count: 5, context: "", evidence: { event_indices: [] } },
+        ],
+      }),
+    ];
+
+    const trends = computeDailyTrends(records, ["2026-02-04", "2026-02-05", "2026-02-06"]);
+    expect(trends).toHaveLength(3);
+    expect(trends[0]!.counts).toEqual({}); // 2026-02-04: no signals
+    expect(trends[1]!.counts["tool_failure_cascade"]).toBe(8); // 3 + 5
+    expect(trends[1]!.counts["context_churn"]).toBe(2);
+    expect(trends[2]!.counts).toEqual({}); // 2026-02-06: no signals
+  });
+
+  it("returns empty counts for days with no records", () => {
+    const trends = computeDailyTrends([], ["2026-02-05"]);
+    expect(trends).toHaveLength(1);
+    expect(trends[0]!.counts).toEqual({});
+  });
+});
+
+// ── classifyTrend ───────────────────────────────────────────────────
+
+describe("classifyTrend", () => {
+  it("returns 'new' when signal not present", () => {
+    const trends = [
+      { date: "2026-02-01", counts: {} },
+      { date: "2026-02-02", counts: {} },
+    ];
+    expect(classifyTrend("tool_failure_cascade", trends)).toBe("new");
+  });
+
+  it("returns 'new' for signal only on the last day", () => {
+    const trends = [
+      { date: "2026-02-01", counts: {} },
+      { date: "2026-02-02", counts: {} },
+      { date: "2026-02-03", counts: { tool_failure_cascade: 3 } },
+    ];
+    expect(classifyTrend("tool_failure_cascade", trends)).toBe("new");
+  });
+
+  it("returns 'new' for fewer than 3 active days", () => {
+    const trends = [
+      { date: "2026-02-01", counts: { retry_loop: 1 } },
+      { date: "2026-02-02", counts: {} },
+      { date: "2026-02-03", counts: { retry_loop: 2 } },
+    ];
+    expect(classifyTrend("retry_loop", trends)).toBe("new");
+  });
+
+  it("returns 'increasing' when second half > first half", () => {
+    const trends = [
+      { date: "2026-02-01", counts: { retry_loop: 1 } },
+      { date: "2026-02-02", counts: { retry_loop: 1 } },
+      { date: "2026-02-03", counts: { retry_loop: 1 } },
+      { date: "2026-02-04", counts: { retry_loop: 5 } },
+      { date: "2026-02-05", counts: { retry_loop: 5 } },
+      { date: "2026-02-06", counts: { retry_loop: 5 } },
+    ];
+    expect(classifyTrend("retry_loop", trends)).toBe("increasing");
+  });
+
+  it("returns 'decreasing' when second half < first half", () => {
+    const trends = [
+      { date: "2026-02-01", counts: { retry_loop: 5 } },
+      { date: "2026-02-02", counts: { retry_loop: 5 } },
+      { date: "2026-02-03", counts: { retry_loop: 5 } },
+      { date: "2026-02-04", counts: { retry_loop: 1 } },
+      { date: "2026-02-05", counts: { retry_loop: 1 } },
+      { date: "2026-02-06", counts: { retry_loop: 1 } },
+    ];
+    expect(classifyTrend("retry_loop", trends)).toBe("decreasing");
+  });
+
+  it("returns 'stable' when halves are roughly equal", () => {
+    const trends = [
+      { date: "2026-02-01", counts: { retry_loop: 3 } },
+      { date: "2026-02-02", counts: { retry_loop: 3 } },
+      { date: "2026-02-03", counts: { retry_loop: 3 } },
+      { date: "2026-02-04", counts: { retry_loop: 3 } },
+      { date: "2026-02-05", counts: { retry_loop: 3 } },
+      { date: "2026-02-06", counts: { retry_loop: 3 } },
+    ];
+    expect(classifyTrend("retry_loop", trends)).toBe("stable");
+  });
+});
+
+// ── buildPrompt ─────────────────────────────────────────────────────
+
+describe("buildPrompt", () => {
+  it("includes scope in prompt", () => {
+    const prompt = buildPrompt("project:/myapp", [makeSignalRecord()], []);
+    expect(prompt).toContain("project:/myapp");
+  });
+
+  it("includes signal data", () => {
+    const prompt = buildPrompt("pai", [makeSignalRecord()], []);
+    expect(prompt).toContain("tool_failure_cascade");
+    expect(prompt).toContain("consecutive tool failures");
+  });
+
+  it("includes trend table", () => {
+    const trends = [{ date: "2026-02-05", counts: { retry_loop: 3 } }];
+    const prompt = buildPrompt("pai", [makeSignalRecord()], trends);
+    expect(prompt).toContain("2026-02-05: retry_loop=3");
+  });
+
+  it("requests JSON output matching PatternAnalysis schema", () => {
+    const prompt = buildPrompt("pai", [makeSignalRecord()], []);
+    expect(prompt).toContain("patterns");
+    expect(prompt).toContain("delight_patterns");
+    expect(prompt).toContain("summary");
+    expect(prompt).toContain("root_cause_hypothesis");
+    expect(prompt).toContain("suggested_fix");
+  });
+});
+
+// ── analyzeScope ────────────────────────────────────────────────────
+
+describe("analyzeScope", () => {
+  it("returns analysis from Ollama", async () => {
+    const config = makeConfig();
+    const client = mockOllamaClient();
+    const records = [makeSignalRecord()];
+    const trends = [{ date: "2026-02-05", counts: { tool_failure_cascade: 3 } }];
+
+    const result = await analyzeScope("project:/myapp", records, trends, client, config);
+    expect(result.skipped).toBe(false);
+    expect(result.analysis.patterns.length).toBeGreaterThan(0);
+    expect(result.analysis.summary).toBeTruthy();
+  });
+
+  it("skips when Ollama is unavailable", async () => {
+    const config = makeConfig();
+    const client = mockUnavailableClient();
+    const warnings: string[] = [];
+
+    const result = await analyzeScope(
+      "pai",
+      [makeSignalRecord()],
+      [],
+      client,
+      config,
+      (msg) => warnings.push(msg),
+    );
+
+    expect(result.skipped).toBe(true);
+    expect(result.analysis.patterns).toEqual([]);
+    expect(warnings.some((w) => w.includes("not available"))).toBe(true);
+  });
+
+  it("skips when no records meet min_session_signals", async () => {
+    const config = makeConfig();
+    const client = mockOllamaClient();
+    const records = [makeSignalRecord({ signals: [] })]; // no signals
+
+    const result = await analyzeScope("pai", records, [], client, config);
+    expect(result.skipped).toBe(true);
+  });
+
+  it("handles Ollama errors gracefully", async () => {
+    const config = makeConfig();
+    const client: OllamaClient = {
+      generate: async () => { throw new Error("boom"); },
+      generateJSON: async () => { throw new Error("boom"); },
+      isAvailable: async () => true,
+    };
+    const warnings: string[] = [];
+
+    const result = await analyzeScope(
+      "pai",
+      [makeSignalRecord()],
+      [],
+      client,
+      config,
+      (msg) => warnings.push(msg),
+    );
+
+    expect(result.skipped).toBe(true);
+    expect(warnings.some((w) => w.includes("failed"))).toBe(true);
+  });
+});
+
+// ── runAnalysis ─────────────────────────────────────────────────────
+
+describe("runAnalysis", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "analyzer-run-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty when no signal files", async () => {
+    const config = makeConfig();
+    const client = mockOllamaClient();
+
+    const results = await runAnalysis(config, client, {
+      signalsDir: tmpDir,
+      referenceDate: new Date("2026-02-07T12:00:00Z"),
+    });
+
+    expect(results).toEqual([]);
+  });
+
+  it("analyzes signals grouped by scope", async () => {
+    const r1 = makeSignalRecord({ scope: "project:/a", timestamp: "2026-02-05T10:00:00.000Z" });
+    const r2 = makeSignalRecord({ scope: "project:/b", timestamp: "2026-02-05T11:00:00.000Z" });
+
+    await writeFile(
+      join(tmpDir, "2026-02-05_signals.jsonl"),
+      JSON.stringify(r1) + "\n" + JSON.stringify(r2) + "\n",
+    );
+
+    const config = makeConfig();
+    const client = mockOllamaClient();
+
+    const results = await runAnalysis(config, client, {
+      signalsDir: tmpDir,
+      referenceDate: new Date("2026-02-07T12:00:00Z"),
+    });
+
+    expect(results).toHaveLength(2);
+    const scopes = results.map((r) => r.scope).sort();
+    expect(scopes).toEqual(["project:/a", "project:/b"]);
+  });
+
+  it("passes warnings through", async () => {
+    await writeFile(
+      join(tmpDir, "2026-02-05_signals.jsonl"),
+      JSON.stringify(makeSignalRecord({ timestamp: "2026-02-05T10:00:00.000Z" })) + "\n",
+    );
+
+    const config = makeConfig();
+    const client = mockUnavailableClient();
+    const warnings: string[] = [];
+
+    await runAnalysis(config, client, {
+      signalsDir: tmpDir,
+      referenceDate: new Date("2026-02-07T12:00:00Z"),
+      warn: (msg) => warnings.push(msg),
+    });
+
+    expect(warnings.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/lib/pattern-analyzer.ts` with the full daily batch analysis pipeline:
  - `loadSignalRecords(days, dir)` — reads JSONL signal files for specified date range
  - `groupByScope(records)` — groups signals by pai/project scope
  - `computeDailyTrends(records, days)` — builds signal count trend tables per day
  - `classifyTrend(signalType, trends)` — classifies as increasing/stable/decreasing/new based on first-half vs second-half comparison
  - `buildPrompt(scope, records, trends)` — constructs structured Ollama prompt requesting PatternAnalysis JSON
  - `analyzeScope(...)` / `runAnalysis(...)` — orchestrates per-scope analysis via Ollama
- Handles Ollama downtime gracefully (returns `skipped: true`)
- Adds `src/pattern-analyzer.ts` as executable entry point (`#!/usr/bin/env bun`)
- Exports all functions from `src/index.ts`

## Test plan
- [x] 29 pattern analyzer tests pass (`bun test tests/pattern-analyzer.test.ts`)
- [x] Full suite of 272 tests pass (`bun test`)
- [x] TypeScript typechecks clean (`bun run typecheck`)

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)